### PR TITLE
Serializar los turnos de una misma conversación

### DIFF
--- a/app/followup.py
+++ b/app/followup.py
@@ -17,6 +17,7 @@ from app.llm import LlmExhausted
 from app.profile import resolve_profile
 from app.prompt import FOLLOWUP_INSTRUCTION, build_system_prompt
 from app.state import AppContext, Conversation, utcnow
+from app.turn import conversation_lock
 from app.turn import _agent_tz
 
 logger = logging.getLogger("nea.followup")
@@ -43,15 +44,33 @@ class FollowupWorker:
             if not await self._ctx.store.claim_followup(conv.id):
                 continue
             try:
-                await self._push(conv)
+                # Mismo candado que los turnos: sin él, el empujón puede salir
+                # encimado con la respuesta de un turno vivo (dos mensajes del
+                # agente a la vez). El valor se copia ANTES del candado porque
+                # el Store puede devolver el mismo objeto vivo (MemoryStore) y
+                # compararlo contra sí mismo no detectaría nada.
+                ultimo_inbound = conv.last_inbound_at
+                async with conversation_lock(self._ctx, conv.wa_identity):
+                    await self._push(conv, ultimo_inbound)
             except Exception:
                 logger.exception(
                     "followup de %s falló — queda consumido (a lo sumo uno)",
                     conv.wa_identity,
                 )
 
-    async def _push(self, conv: Conversation) -> None:
+    async def _push(
+        self, conv: Conversation, ultimo_inbound: datetime | None
+    ) -> None:
         ctx = self._ctx
+        # Si mientras esperábamos el candado el lead escribió, el empujón sobra:
+        # ya hay conversación viva y "¿seguimos?" quedaría fuera de lugar.
+        fresca = await ctx.store.get_or_create_conversation(conv.wa_identity)
+        if fresca.last_inbound_at != ultimo_inbound:
+            logger.info(
+                "followup %s: el lead escribió mientras tanto — omitido",
+                conv.wa_identity,
+            )
+            return
         try:
             context = await ctx.crm.get_context(conv.wa_identity)
         except CrmError as exc:

--- a/app/state.py
+++ b/app/state.py
@@ -352,3 +352,10 @@ class AppContext:
     profile: Any | None = None  # ProfileProvider; None en tests = perfil mínimo
     coalescer: Any | None = None
     relay_wake: asyncio.Event = field(default_factory=asyncio.Event)
+    # Un candado por identidad: los turnos de UNA conversación se serializan.
+    # Sin esto, una ráfaga que llega mientras el turno anterior sigue en vuelo
+    # abre un segundo turno con contexto viejo (se reservó una cita antes de
+    # leer el mensaje que la corregía, y salieron dos respuestas encimadas).
+    turn_locks: dict[str, asyncio.Lock] = field(default_factory=dict)
+    # Cuántos turnos tienen tomado (o esperan) el candado de esa identidad.
+    turn_lock_users: dict[str, int] = field(default_factory=dict)

--- a/app/turn.py
+++ b/app/turn.py
@@ -9,8 +9,9 @@ from __future__ import annotations
 import asyncio
 import json
 import logging
+from contextlib import asynccontextmanager
 from datetime import timedelta
-from typing import Any
+from typing import Any, AsyncIterator
 from zoneinfo import ZoneInfo
 
 from app import media
@@ -42,10 +43,47 @@ def _agent_tz(settings: Any) -> ZoneInfo:
         return ZoneInfo("America/Mexico_City")
 
 
+@asynccontextmanager
+async def conversation_lock(ctx: AppContext, identity: str) -> AsyncIterator[None]:
+    """Serializa los turnos de UNA conversación.
+
+    El coalescer agrupa ráfagas por debounce, pero nada le impide disparar un
+    turno nuevo mientras el anterior sigue corriendo: el mensaje que llega
+    tarde abre su propio turno con el contexto de ANTES de que el turno vivo
+    actuara. Así se reserva una cita sin haber leído el mensaje que la
+    corregía, y salen dos respuestas pisándose.
+
+    Con el candado, el turno tardío espera, y al arrancar re-lee el contexto
+    del CRM y el historial — que ya incluyen lo que hizo el turno anterior.
+    """
+    lock = ctx.turn_locks.get(identity)
+    if lock is None:
+        lock = ctx.turn_locks[identity] = asyncio.Lock()
+    # El conteo sube ANTES del await: quien ya tiene el objeto en mano queda
+    # contado, así que el candado nunca se recicla debajo de un turno que
+    # espera (y el diccionario no crece sin fin con cada lead histórico).
+    ctx.turn_lock_users[identity] = ctx.turn_lock_users.get(identity, 0) + 1
+    if lock.locked():
+        logger.info(
+            "turno de %s en vuelo — el mensaje nuevo espera su turno", identity
+        )
+    try:
+        async with lock:
+            yield
+    finally:
+        remaining = ctx.turn_lock_users.get(identity, 1) - 1
+        if remaining <= 0:
+            ctx.turn_lock_users.pop(identity, None)
+            ctx.turn_locks.pop(identity, None)
+        else:
+            ctx.turn_lock_users[identity] = remaining
+
+
 async def handle_flush(ctx: AppContext, identity: str, items: list[Any]) -> None:
     """Callback del coalescer — nunca propaga excepciones."""
     try:
-        await run_turn(ctx, identity, items)
+        async with conversation_lock(ctx, identity):
+            await run_turn(ctx, identity, items)
     except Exception:
         logger.exception("turno de %s reventó — silencio", identity)
 

--- a/tests/test_followup.py
+++ b/tests/test_followup.py
@@ -1,6 +1,7 @@
 """Seguimiento: UN empujón y solo uno, marcado ANTES de enviar."""
 from __future__ import annotations
 
+import asyncio
 from datetime import timedelta
 
 import httpx
@@ -8,6 +9,7 @@ import httpx
 from app.followup import FollowupWorker
 from app.llm import LlmReply
 from app.state import utcnow
+from app.turn import conversation_lock
 from tests.conftest import (
     CRM_CONV_ID,
     CRM_URL,
@@ -105,4 +107,31 @@ async def test_followup_llm_caido_se_omite_sin_reintento_futuro(respx_mock):
     await worker.tick()
     assert messages.call_count == 0
     assert ctx.store.conversations[conv.id].followup_sent is True  # consumido
+    await ctx.crm.aclose()
+
+
+async def test_followup_espera_el_turno_vivo_y_se_calla_si_el_lead_escribio(respx_mock):
+    """El empujón se reclama antes de enviarlo. Si mientras espera su turno el
+    lead escribe, el "¿seguimos?" queda fuera de lugar — y encimado con la
+    respuesta del turno vivo."""
+    ctx = make_ctx()
+    ctx.llm.replies = [LlmReply(content="¿Seguimos donde nos quedamos? 😊")]
+    conv = await preparar_conversacion(ctx)
+    respx_mock.get(f"{CRM_URL}/api/bot/context").mock(
+        return_value=httpx.Response(200, json=crm_context())
+    )
+    messages = respx_mock.post(f"{CRM_URL}/api/bot/messages").mock(
+        return_value=httpx.Response(200, json={"messageId": "m1"})
+    )
+
+    # Un turno del lead ya está en vuelo: tiene el candado tomado.
+    async with conversation_lock(ctx, IDENTITY):
+        tarea = asyncio.create_task(FollowupWorker(ctx).tick())
+        await asyncio.sleep(0.05)
+        assert messages.call_count == 0, "el empujón no esperó al turno vivo"
+        # Ese turno registra el mensaje del lead y luego suelta el candado.
+        await ctx.store.update_conversation(conv.id, last_inbound_at=utcnow())
+    await tarea
+
+    assert messages.call_count == 0  # ya hubo conversación: sin empujón
     await ctx.crm.aclose()

--- a/tests/test_turn.py
+++ b/tests/test_turn.py
@@ -5,7 +5,7 @@ import asyncio
 import json
 
 from app.llm import LlmExhausted, LlmReply, ToolCall
-from tests.conftest import mock_crm_basics, wa_body
+from tests.conftest import FakeLLM, mock_crm_basics, wa_body
 
 
 async def test_handoff_despedida_primero_pausa_despues(ctx, client, respx_mock):
@@ -72,3 +72,38 @@ async def test_turno_con_route_out_cierra_sin_seguimiento(ctx, client, respx_moc
     conv = next(iter(ctx.store.conversations.values()))
     assert conv.phase == "cerrada"
     assert conv.followup_due_at is None
+
+
+async def test_los_turnos_de_una_conversacion_no_se_encinan(ctx, client, respx_mock):
+    """Un mensaje que llega tarde NO abre un turno con el contexto de antes.
+
+    Dos mensajes con segundos de diferencia: el segundo abría su propio turno
+    mientras el primero seguía corriendo, así que la cita se reservaba sin
+    haber leído el mensaje que la corregía y salían dos respuestas encimadas.
+    """
+    routes = mock_crm_basics(respx_mock)
+
+    class LlmLento(FakeLLM):
+        async def complete(self, messages, tools=None):
+            await asyncio.sleep(0.3)
+            return await super().complete(messages, tools)
+
+    ctx.llm = LlmLento()
+
+    await client.post("/webhook", content=wa_body(text="Si 10.30", wamid="wamid.a"))
+    await asyncio.sleep(0.15)  # el turno A ya arrancó y sigue en el LLM
+    await client.post("/webhook", content=wa_body(text="De mañana", wamid="wamid.b"))
+    await asyncio.sleep(1.2)
+
+    assert routes["messages"].call_count == 2  # una respuesta por turno...
+    rutas = [
+        str(c.request.url.path)
+        for c in respx_mock.calls
+        if str(c.request.url.path) in ("/api/bot/context", "/api/bot/messages")
+    ]
+    # ...y el turno B lee el contexto DESPUÉS de que A mandó la suya: si no,
+    # decide sobre un estado que ya cambió.
+    assert rutas.count("/api/bot/context") == 2
+    assert rutas.index("/api/bot/messages") < rutas.index(
+        "/api/bot/context", rutas.index("/api/bot/context") + 1
+    )


### PR DESCRIPTION
El coalescer agrupa ráfagas por debounce, pero nada le impedía disparar un turno nuevo mientras el anterior seguía corriendo. Con dos mensajes separados por unos segundos, el segundo abría su propio turno con el contexto de **antes** de que el turno vivo actuara.

En vivo se vio así: el lead mandó `"Si 10.30"` y siete segundos después `"De mañana"`. El primer turno reservó la cita sin haber leído nunca la palabra "mañana", y las dos respuestas salieron en el mismo segundo.

## Qué cambia

- `turn.conversation_lock`: un candado por identidad. El turno tardío espera y, al arrancar, re-lee contexto e historial — que ya incluyen lo que hizo el turno anterior. Lleva refcount para que el diccionario no crezca sin fin con cada lead histórico ni se recicle debajo de un turno que espera.
- El worker de seguimiento usa el **mismo** candado. Mandaba por fuera, así que el empujón de las N horas podía salir encimado con la respuesta de un turno vivo. Además ahora se calla si el lead escribió mientras esperaba su turno: un "¿seguimos?" justo después de que la persona habló queda fuera de lugar.

## Verificación

79/79 pytest. Los dos tests nuevos fallan si se quita el candado: sin él, ambos turnos leen el contexto antes de que salga ninguna respuesta.