### PR TITLE
Agenda sin ambigüedad de fecha: reparto por día, confirmación explícita y reagendado

### DIFF
--- a/app/crm.py
+++ b/app/crm.py
@@ -6,8 +6,9 @@ Endpoints:
   POST /api/bot/messages   {conversationId, text}   → 409 ai_paused|window_closed
   PUT  /api/bot/ficha      {conversationId, ficha}
   POST /api/bot/handoff    {conversationId, reason}
-  GET  /api/bot/availability?limit=6
+  GET  /api/bot/availability?limit=&perDay=&days=   → huecos repartidos por día
   POST /api/bot/bookings   {conversationId, startUtc} → 409 slot_taken + slots frescos
+  PATCH /api/bot/bookings  {conversationId, startUtc} → mueve la próxima cita
   GET  /api/bot/media/{mediaId}                       → binario + content-type
   POST /api/bot/reset      {conversationId}           → reinicio de pruebas (002)
 """
@@ -42,11 +43,36 @@ class SlotTaken(CrmConflict):
         self.slots: list[dict[str, Any]] = list((payload or {}).get("slots") or [])
 
 
-def _conflict_code(response: httpx.Response) -> str:
+def _payload(response: httpx.Response) -> dict[str, Any]:
     try:
-        return str(response.json().get("code") or "conflict")
+        data = response.json()
     except Exception:
-        return "conflict"
+        return {}
+    return data if isinstance(data, dict) else {}
+
+
+def _conflict_code(response: httpx.Response) -> str:
+    """Código tipado de un 409.
+
+    El CRM anida `{"error": {"code": ...}}`; la forma plana `{"code": ...}`
+    solo vivía en los mocks, así que en producción TODO 409 se leía como
+    "conflict" genérico y el camino de `slot_taken` (re-ofrecer alternativas
+    frescas) nunca se activaba. Se toleran las dos formas.
+    """
+    payload = _payload(response)
+    nested = payload.get("error")
+    if isinstance(nested, dict) and nested.get("code"):
+        return str(nested["code"])
+    return str(payload.get("code") or "conflict")
+
+
+def _booking_conflict(response: httpx.Response) -> CrmConflict:
+    """409 de agenda: `slot_taken` viene con alternativas frescas adjuntas."""
+    payload = _payload(response)
+    code = _conflict_code(response)
+    if code == "slot_taken":
+        return SlotTaken(payload)
+    return CrmConflict(code, payload)
 
 
 # Catálogo cerrado del CRM para handoff.reason (006). El LLM escribe motivos
@@ -150,10 +176,21 @@ class CrmClient:
         if resp.status_code != 200:
             raise CrmError(f"handoff devolvió {resp.status_code}")
 
-    async def get_availability(self, limit: int = 6) -> list[dict[str, Any]]:
-        resp = await self._request(
-            "GET", "/api/bot/availability", params={"limit": limit}
-        )
+    async def get_availability(
+        self,
+        limit: int = 6,
+        per_day: int | None = None,
+        days: int | None = None,
+    ) -> list[dict[str, Any]]:
+        """Huecos libres. Con `per_day` el CRM los reparte entre días distintos
+        (si no, los primeros N se los come el día de hoy) y los devuelve con el
+        día desambiguado en `dayLabel`."""
+        params: dict[str, Any] = {"limit": limit}
+        if per_day:
+            params["perDay"] = per_day
+        if days:
+            params["days"] = days
+        resp = await self._request("GET", "/api/bot/availability", params=params)
         if resp.status_code != 200:
             raise CrmError(f"availability devolvió {resp.status_code}")
         slots = resp.json().get("slots") or []
@@ -168,17 +205,32 @@ class CrmClient:
             json={"conversationId": conversation_id, "startUtc": start_utc},
         )
         if resp.status_code == 409:
-            payload: dict[str, Any] = {}
-            try:
-                payload = resp.json()
-            except Exception:
-                pass
-            if payload.get("code") == "slot_taken":
-                raise SlotTaken(payload)
-            raise CrmConflict(_conflict_code(resp), payload)
+            raise _booking_conflict(resp)
         # El CRM real responde 201 Created (REST); los mocks viejos daban 200.
         if resp.status_code not in (200, 201):
             raise CrmError(f"bookings devolvió {resp.status_code}")
+        data: dict[str, Any] = resp.json()
+        return data
+
+    async def reschedule_booking(
+        self, conversation_id: str, start_utc: str
+    ) -> dict[str, Any]:
+        """Mueve la PRÓXIMA cita activa del lead a otro horario ofrecido.
+
+        Antes esto no existía y el agente tenía que hacer handoff: la IA se
+        pausaba y el lead quedaba sin nadie del otro lado.
+        """
+        resp = await self._request(
+            "PATCH",
+            "/api/bot/bookings",
+            json={"conversationId": conversation_id, "startUtc": start_utc},
+        )
+        if resp.status_code == 409:
+            raise _booking_conflict(resp)
+        if resp.status_code == 404:
+            raise CrmConflict("no_booking", _payload(resp))
+        if resp.status_code != 200:
+            raise CrmError(f"reschedule devolvió {resp.status_code}")
         data: dict[str, Any] = resp.json()
         return data
 

--- a/app/prompt.py
+++ b/app/prompt.py
@@ -12,7 +12,7 @@ comportamiento end-to-end (ver README, "Definición de Hecho").
 from __future__ import annotations
 
 import json
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 from zoneinfo import ZoneInfo
 
 from app.profile import BusinessProfile
@@ -39,8 +39,12 @@ CONVERSACIÓN:
 3) Decide la salida según los criterios del negocio. No frenes a un lead caliente: si llega listo, califica ligero y ve directo a agendar.
 
 AGENDAR:
-→ Cuando el lead acepta tener la cita, llama propose_slots (te da horarios reales de la agenda del negocio); ofrece MÁXIMO 3, con su etiqueta tal cual te la doy. Cuando el lead elija, llama book_session con el start_utc EXACTO del slot elegido — solo los ofrecidos son reservables. Al confirmar: repite día y hora y lo que el negocio indique para preparar la cita.
-→ Si piden reagendar o cancelar una cita ya creada: haz handoff (eso lo resuelve el equipo, tú no reagendas).
+→ Cuando el lead acepta tener la cita, llama propose_slots — te regresa los horarios reales de la agenda del negocio repartidos entre los próximos días, cada uno con su día explícito. Ofrece MÁXIMO 3 a la vez, con su etiqueta tal cual te la doy, escogiendo los que mejor embonen con lo que el lead pidió. Si pide un día o una franja que NO viene en la lista, dilo derecho ("ese día no hay agenda") y ofrécele lo más cercano que sí exista — NUNCA acomodes su petición en otro día como si fuera lo mismo.
+→ ANTES de reservar, confirma la fecha completa y espera un sí inequívoco: "¿te aparto el viernes 7 de agosto a las 10:30 de la mañana?". Un "sí", un "10:30" o un "de mañana" sueltos NO bastan si no caen sobre un día concreto que TÚ ya nombraste en el mensaje anterior. Ante cualquier duda de qué día quiso decir, preguntas: reservar el día equivocado cuesta muchísimo más que preguntar una vez.
+→ Pero se pregunta UNA sola vez. Si ya nombraste un día y hora concretos y el lead dijo que sí (o "va", "sale", "ese"), RESERVAS en ese mismo turno — volver a preguntar lo mismo es un bucle y se siente a desconfianza. Solo vuelves a preguntar si el lead cambió de opción o metió un dato nuevo que contradice lo que ibas a apartar.
+→ Ya sin duda, llama book_session con el start_utc EXACTO del slot elegido (solo los ofrecidos son reservables) y con dia_confirmado = lo que el lead escribió para aceptar ESE día. Al confirmar: día completo y hora, y lo que el negocio indique para preparar la cita.
+→ Si quiere MOVER una cita ya agendada, la mueves TÚ: propose_slots, confirmas la fecha completa igual que arriba, y hasta entonces reschedule_session. Eso no es handoff.
+→ Si quiere CANCELAR: handoff — esa la decide el equipo.
 
 SI NO CALIFICA (según los criterios del negocio):
 → Despídelo con honestidad y sin herir, dejando la puerta abierta. Si el negocio definió recursos alternativos, compártelos. Llama route_out para registrarlo.
@@ -50,8 +54,9 @@ Hostilidad: una grosería suelta no te inmuta — aguantas vara con dignidad, si
 
 HERRAMIENTAS (jamás las menciones al lead, ni nada técnico):
 - update_ficha: cada vez que descubras un dato nuevo del lead. Manda solo lo nuevo.
-- propose_slots: solo cuando el lead aceptó tener la cita.
-- book_session: solo con el start_utc de un slot que TÚ ofreciste en esta conversación.
+- propose_slots: solo cuando el lead aceptó tener la cita (o cuando quiere mover la que ya tiene).
+- book_session: solo con el start_utc de un slot que TÚ ofreciste en esta conversación, y solo tras confirmar la fecha completa.
+- reschedule_session: mover la cita YA agendada a otro slot ofrecido, con el mismo protocolo de confirmación.
 - route_out: al decidir que el lead no califica y despedirlo.
 - handoff: al decidir pasar a humano (o si no puedes resolver algo).
 
@@ -103,8 +108,30 @@ def _business_block(profile: BusinessProfile) -> str:
     return "\n\n".join(lines)
 
 
+# Nombres en español a mano: la imagen corre con locale C, así que
+# strftime("%A %d de %B") escupía "Friday 07 de August" — mitad en inglés y
+# encima sin decirle nunca al agente qué día cae mañana.
+DIAS = (
+    "lunes", "martes", "miércoles", "jueves", "viernes", "sábado", "domingo",
+)
+MESES = (
+    "enero", "febrero", "marzo", "abril", "mayo", "junio", "julio",
+    "agosto", "septiembre", "octubre", "noviembre", "diciembre",
+)
+
+
+def fecha_es(dt: datetime, tz: ZoneInfo) -> str:
+    """"viernes 7 de agosto de 2026" en la zona dada, sin depender del locale."""
+    local = dt.astimezone(tz)
+    return (
+        f"{DIAS[local.weekday()]} {local.day} de {MESES[local.month - 1]} "
+        f"de {local.year}"
+    )
+
+
 def _fmt_local(dt: datetime, tz: ZoneInfo) -> str:
-    return dt.astimezone(tz).strftime("%A %d de %B, %H:%M") + f" ({tz.key})"
+    local = dt.astimezone(tz)
+    return f"{fecha_es(dt, tz)}, {local:%H:%M} ({tz.key})"
 
 
 def build_system_prompt(
@@ -122,6 +149,15 @@ def build_system_prompt(
     now = now or datetime.now(timezone.utc)
     lines: list[str] = ["", "CONTEXTO ACTUAL:"]
     lines.append(f"- Fecha y hora: {_fmt_local(now, tz)}.")
+    # "Mañana" resuelto por el sistema: el lead lo dice todo el tiempo y el
+    # modelo no tiene por qué calcularlo (ni equivocarse de día).
+    lines.append(
+        f'- "Hoy" es {fecha_es(now, tz)} y "mañana" es '
+        f'{fecha_es(now + timedelta(days=1), tz)}. Ojo con la ambigüedad del '
+        'español: "de mañana" puede querer decir "de la mañana" (AM) o "del '
+        "día de mañana\" — si el lead lo usa para una fecha y no queda "
+        "clarísimo, pregúntale antes de reservar nada."
+    )
 
     contact = (context or {}).get("contact") or {}
     lead = (context or {}).get("lead") or {}
@@ -162,7 +198,8 @@ def build_system_prompt(
     if booking:
         lines.append(
             f"- El lead YA tiene cita agendada: {booking.get('label') or booking.get('scheduledAt')}. "
-            "No agendes otra; si quiere cambiarla, handoff."
+            "No agendes otra. Si quiere moverla, usa reschedule_session (no "
+            "book_session); si quiere cancelarla, handoff."
         )
 
     return (

--- a/app/tools.py
+++ b/app/tools.py
@@ -11,13 +11,20 @@ import logging
 from datetime import datetime, timezone
 from typing import Any
 
-from app.crm import CrmError, SlotTaken
+from app.crm import CrmConflict, CrmError, SlotTaken
 from app.profile import BusinessProfile
 from app.state import AppContext, Conversation, OfferedSlot
 
 logger = logging.getLogger("nea.tools")
 
-MAX_OFFERED = 3
+# Cuántos huecos quedan RESERVABLES tras un propose_slots. El agente muestra 3
+# a la vez (regla del prompt), pero guardar solo 3 lo dejaba sin nada que
+# ofrecer cuando el lead pedía otro día: el catálogo reservable es más ancho
+# que el menú que se enseña.
+MAX_OFFERED = 12
+# Reparto pedido al CRM: hasta 3 huecos por día, en 5 días distintos.
+OFFER_PER_DAY = 3
+OFFER_DAYS = 5
 
 TOOL_SCHEMAS: list[dict[str, Any]] = [
     {
@@ -55,9 +62,12 @@ TOOL_SCHEMAS: list[dict[str, Any]] = [
         "function": {
             "name": "propose_slots",
             "description": (
-                "Consulta la disponibilidad real de la agenda del negocio y te "
-                "regresa hasta 3 horarios para ofrecer al lead (con etiqueta en "
-                "español). SOLO estos horarios serán reservables después."
+                "Consulta la disponibilidad real de la agenda del negocio. Te "
+                "regresa los huecos libres REPARTIDOS entre los próximos días, "
+                "cada uno con su día en palabras (hoy/mañana/nombre del día). "
+                "Ofrece al lead máximo 3, los que embonen con lo que pidió. Si "
+                "el día que pidió no aparece, es que no hay agenda ese día: "
+                "dilo. SOLO estos horarios serán reservables después."
             ),
             "parameters": {"type": "object", "properties": {}},
         },
@@ -69,7 +79,8 @@ TOOL_SCHEMAS: list[dict[str, Any]] = [
             "description": (
                 "Reserva la cita en uno de los horarios previamente ofrecidos. "
                 "start_utc debe ser EXACTAMENTE el start_utc de un slot ofrecido "
-                "en esta conversación."
+                "en esta conversación. Llámala SOLO después de haber nombrado el "
+                "día completo y de que el lead lo aceptara sin ambigüedad."
             ),
             "parameters": {
                 "type": "object",
@@ -77,9 +88,42 @@ TOOL_SCHEMAS: list[dict[str, Any]] = [
                     "start_utc": {
                         "type": "string",
                         "description": "ISO 8601 UTC del slot elegido, tal cual se ofreció",
-                    }
+                    },
+                    "dia_confirmado": {
+                        "type": "string",
+                        "description": (
+                            "Lo que el lead escribió para aceptar ESE día concreto. "
+                            "Si no puedes citarlo, todavía no confirmó: pregunta "
+                            "en vez de reservar."
+                        ),
+                    },
                 },
-                "required": ["start_utc"],
+                "required": ["start_utc", "dia_confirmado"],
+            },
+        },
+    },
+    {
+        "type": "function",
+        "function": {
+            "name": "reschedule_session",
+            "description": (
+                "Mueve la cita YA agendada del lead a otro horario ofrecido. "
+                "Mismo protocolo que book_session: primero propose_slots, luego "
+                "confirmas el día completo, y hasta entonces mueves."
+            ),
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "start_utc": {
+                        "type": "string",
+                        "description": "ISO 8601 UTC del nuevo slot, tal cual se ofreció",
+                    },
+                    "dia_confirmado": {
+                        "type": "string",
+                        "description": "Lo que el lead escribió para aceptar ESE día",
+                    },
+                },
+                "required": ["start_utc", "dia_confirmado"],
             },
         },
     },
@@ -132,6 +176,21 @@ def _parse_utc(value: str) -> datetime | None:
     return dt
 
 
+def _label_of(raw: dict[str, Any], start: datetime) -> str:
+    """Etiqueta con el día en palabras: "hoy viernes 7 de agosto, 10:30".
+
+    La corta del CRM ("vie 7 ago, 10:30") se presta a que el lead entienda
+    otro día: basta que conteste "10:30, de mañana" a una oferta de HOY para
+    agendar mal. Si el CRM no manda `dayLabel` (respuestas sin reparto, p. ej.
+    las alternativas de un slot_taken), se cae a la corta.
+    """
+    day_label = str(raw.get("dayLabel") or "").strip()
+    time = str(raw.get("time") or "").strip()
+    if day_label and time:
+        return f"{day_label}, {time}"
+    return str(raw.get("label") or _iso_z(start))
+
+
 def _slots_from_payload(
     conversation_id: int, raw_slots: list[dict[str, Any]]
 ) -> list[OfferedSlot]:
@@ -147,7 +206,7 @@ def _slots_from_payload(
                 conversation_id=conversation_id,
                 start_utc=start,
                 end_utc=end,
-                label=str(raw.get("label") or _iso_z(start)),
+                label=_label_of(raw, start),
             )
         )
     return out
@@ -185,6 +244,8 @@ class ToolRuntime:
                 return await self._propose_slots()
             if name == "book_session":
                 return await self._book_session(args)
+            if name == "reschedule_session":
+                return await self._reschedule_session(args)
             if name == "route_out":
                 return await self._route_out()
             if name == "handoff":
@@ -208,7 +269,9 @@ class ToolRuntime:
         return {"ok": True}
 
     async def _propose_slots(self) -> dict[str, Any]:
-        raw = await self._ctx.crm.get_availability(limit=6)
+        raw = await self._ctx.crm.get_availability(
+            limit=MAX_OFFERED, per_day=OFFER_PER_DAY, days=OFFER_DAYS
+        )
         slots = _slots_from_payload(self._conv.id, raw)
         if not slots:
             return {
@@ -221,34 +284,66 @@ class ToolRuntime:
         return {
             "ok": True,
             "slots": _slots_for_llm(slots),
-            "instrucciones": "ofrece estos horarios con su etiqueta tal cual; máximo 3",
+            "dias_con_agenda": sorted(
+                {s.label.rsplit(",", 1)[0].strip() for s in slots}
+            ),
+            "instrucciones": (
+                "esta es TODA la agenda abierta: los días que no aparecen aquí "
+                "NO tienen agenda, dilo en vez de mover al lead a otro día. "
+                "Ofrécele máximo 3, con su etiqueta tal cual (día incluido), "
+                "los que embonen con lo que pidió."
+            ),
         }
 
-    async def _book_session(self, args: dict[str, Any]) -> dict[str, Any]:
+    async def _resolve_offered(
+        self, args: dict[str, Any], accion: str
+    ) -> tuple[OfferedSlot | None, dict[str, Any] | None]:
+        """Slot elegido, o el error listo para devolverle al LLM.
+
+        Validación server-side por epoch exacto: solo lo ofrecido es reservable.
+        """
         wanted = _parse_utc(str(args.get("start_utc") or ""))
         offered = await self._ctx.store.get_offered_slots(self._conv.id)
         if wanted is None:
-            return {
+            return None, {
                 "ok": False,
                 "error": "start_utc_invalido",
                 "slots_ofrecidos": _slots_for_llm(offered),
             }
-        # Validación server-side por epoch exacto: solo lo ofrecido es reservable.
         chosen = next(
-            (s for s in offered if int(s.start_utc.timestamp()) == int(wanted.timestamp())),
+            (
+                s
+                for s in offered
+                if int(s.start_utc.timestamp()) == int(wanted.timestamp())
+            ),
             None,
         )
         if chosen is None:
             logger.info(
-                "tools: book_session rechazado — %s no está entre los ofrecidos",
+                "tools: %s rechazado — %s no está entre los ofrecidos",
+                accion,
                 args.get("start_utc"),
             )
-            return {
+            return None, {
                 "ok": False,
                 "error": "slot_no_ofrecido",
-                "detalle": "solo puedes reservar un horario que ya ofreciste",
+                "detalle": "solo puedes agendar un horario que ya ofreciste",
                 "slots_ofrecidos": _slots_for_llm(offered),
             }
+        # Deja rastro de sobre qué frase del lead se tomó la decisión: cuando
+        # una cita sale mal, esto dice si hubo confirmación o se asumió.
+        logger.info(
+            "tools: %s a %s (el lead confirmó con: %r)",
+            accion,
+            chosen.label,
+            str(args.get("dia_confirmado") or "")[:120],
+        )
+        return chosen, None
+
+    async def _book_session(self, args: dict[str, Any]) -> dict[str, Any]:
+        chosen, error = await self._resolve_offered(args, "book_session")
+        if error is not None or chosen is None:
+            return error or {"ok": False, "error": "slot_no_ofrecido"}
         try:
             result = await self._ctx.crm.create_booking(
                 self._crm_conv_id, _iso_z(chosen.start_utc)
@@ -273,12 +368,52 @@ class ToolRuntime:
             logger.warning("tools: no pude actualizar ficha tras booking: %s", exc)
         return {
             "ok": True,
-            "label": result.get("label") or chosen.label,
+            # La etiqueta del slot ofrecido trae el día en palabras; la del
+            # CRM es la corta. Se repite ESTA para que el lead lea el día.
+            "label": chosen.label or result.get("label"),
             "zoom_url": result.get("zoomJoinUrl"),
             "instrucciones": (
-                "confirma día y hora de la cita, comparte el link de la "
-                "videollamada si existe y menciona lo que el negocio pida "
-                "para llegar preparado"
+                "confirma el día COMPLETO y la hora tal cual dice label, "
+                "comparte el link de la videollamada si existe y menciona lo "
+                "que el negocio pida para llegar preparado"
+            ),
+        }
+
+    async def _reschedule_session(self, args: dict[str, Any]) -> dict[str, Any]:
+        chosen, error = await self._resolve_offered(args, "reschedule_session")
+        if error is not None or chosen is None:
+            return error or {"ok": False, "error": "slot_no_ofrecido"}
+        try:
+            result = await self._ctx.crm.reschedule_booking(
+                self._crm_conv_id, _iso_z(chosen.start_utc)
+            )
+        except SlotTaken as exc:
+            fresh = _slots_from_payload(self._conv.id, exc.slots)
+            await self._ctx.store.replace_offered_slots(self._conv.id, fresh)
+            return {
+                "ok": False,
+                "error": "slot_taken",
+                "detalle": "ese horario se acaba de ocupar; discúlpate breve y ofrece estas alternativas",
+                "slots": _slots_for_llm(fresh),
+            }
+        except CrmConflict as exc:
+            if exc.code == "no_booking":
+                return {
+                    "ok": False,
+                    "error": "sin_cita",
+                    "detalle": "el lead no tiene cita por delante; usa book_session",
+                }
+            raise
+        await self._ctx.store.clear_offered_slots(self._conv.id)
+        self.booked = True
+        return {
+            "ok": True,
+            "label": chosen.label or result.get("label"),
+            "zoom_url": result.get("zoomJoinUrl"),
+            "instrucciones": (
+                "confirma que quedó movida, con el día COMPLETO y la hora tal "
+                "cual dice label; el link de la videollamada sigue siendo el "
+                "mismo salvo que aquí venga otro"
             ),
         }
 

--- a/tests/test_sender.py
+++ b/tests/test_sender.py
@@ -48,7 +48,7 @@ async def test_409_no_se_encola(respx_mock):
     ctx = make_ctx()
     conv = await ctx.store.get_or_create_conversation(IDENTITY)
     respx_mock.post(f"{CRM_URL}/api/bot/messages").mock(
-        return_value=httpx.Response(409, json={"code": "ai_paused"})
+        return_value=httpx.Response(409, json={"error": {"code": "ai_paused"}})
     )
 
     sent = await turn._send(ctx, conv.id, CRM_CONV_ID, "hola")
@@ -105,7 +105,7 @@ async def test_sender_abandona_por_409_sin_handoff(respx_mock):
     conv = await ctx.store.get_or_create_conversation(IDENTITY)
     pid = await ctx.store.enqueue_pending_send(conv.id, CRM_CONV_ID, "texto")
     respx_mock.post(f"{CRM_URL}/api/bot/messages").mock(
-        return_value=httpx.Response(409, json={"code": "window_closed"})
+        return_value=httpx.Response(409, json={"error": {"code": "window_closed"}})
     )
     handoff = respx_mock.post(f"{CRM_URL}/api/bot/handoff").mock(
         return_value=httpx.Response(200, json={})

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -85,7 +85,16 @@ async def test_book_slot_taken_ofrece_alternativas_frescas(runtime_y_ctx, respx_
         {"startUtc": "2026-07-21T17:00:00Z", "endUtc": None, "label": "martes 21, 11:00 am"},
     ]
     respx_mock.post(f"{CRM_URL}/api/bot/bookings").mock(
-        return_value=httpx.Response(409, json={"code": "slot_taken", "slots": frescos})
+        # Forma REAL del CRM: el código va anidado bajo "error". El mock plano
+        # de antes escondía que en producción ningún 409 se reconocía y este
+        # camino estaba muerto.
+        return_value=httpx.Response(
+            409,
+            json={
+                "error": {"code": "slot_taken", "message": "ocupado"},
+                "slots": frescos,
+            },
+        )
     )
     result = await runtime.execute("book_session", {"start_utc": SLOT_ISO})
     assert result["ok"] is False
@@ -97,7 +106,12 @@ async def test_book_slot_taken_ofrece_alternativas_frescas(runtime_y_ctx, respx_
     assert runtime.booked is False
 
 
-async def test_propose_slots_maximo_3_y_persistidos(runtime_y_ctx, respx_mock):
+async def test_propose_slots_pide_reparto_por_dia_y_persiste_todos(
+    runtime_y_ctx, respx_mock
+):
+    """El catálogo reservable es ancho a propósito: guardar solo 3 dejaba al
+    agente sin nada que ofrecer cuando el lead pedía otro día. El "máximo 3"
+    es cuántos SE ENSEÑAN, y eso lo gobierna el prompt."""
     runtime, ctx, conv = runtime_y_ctx
     seis = [
         {
@@ -107,15 +121,18 @@ async def test_propose_slots_maximo_3_y_persistidos(runtime_y_ctx, respx_mock):
         }
         for d in range(6)
     ]
-    respx_mock.get(f"{CRM_URL}/api/bot/availability").mock(
+    route = respx_mock.get(f"{CRM_URL}/api/bot/availability").mock(
         return_value=httpx.Response(200, json={"slots": seis})
     )
     result = await runtime.execute("propose_slots", {})
     assert result["ok"] is True
-    assert len(result["slots"]) == 3  # máx 3 por mensaje
-    offered = await ctx.store.get_offered_slots(conv.id)
-    assert len(offered) == 3
+    assert len(result["slots"]) == 6
+    assert len(await ctx.store.get_offered_slots(conv.id)) == 6
     assert runtime.proposed is True
+    # El reparto se le pide al CRM, no se improvisa aquí.
+    params = route.calls[0].request.url.params
+    assert params["perDay"] == "3"
+    assert params["days"] == "5"
 
 
 async def test_update_ficha_manda_lo_que_haya(runtime_y_ctx, respx_mock):
@@ -154,3 +171,91 @@ async def test_crm_caido_en_tool_no_tumba_el_turno(runtime_y_ctx, respx_mock):
     result = await runtime.execute("update_ficha", {"rubro": "ferretería"})
     assert result["ok"] is False
     assert result["error"] == "crm_error"
+
+
+async def test_propose_slots_etiqueta_con_el_dia_en_palabras(
+    runtime_y_ctx, respx_mock
+):
+    """La etiqueta corta ("vie 7 ago, 10:30") se presta a que el lead entienda
+    otro día — basta un "10:30, de mañana" para agendar mal."""
+    runtime, ctx, conv = runtime_y_ctx
+    respx_mock.get(f"{CRM_URL}/api/bot/availability").mock(
+        return_value=httpx.Response(
+            200,
+            json={
+                "slots": [
+                    {
+                        "startUtc": "2026-08-07T16:30:00Z",
+                        "endUtc": "2026-08-07T17:00:00Z",
+                        "label": "vie 7 ago, 10:30",
+                        "dayLabel": "hoy viernes 7 de agosto",
+                        "time": "10:30",
+                    },
+                    {
+                        "startUtc": "2026-08-10T15:00:00Z",
+                        "endUtc": "2026-08-10T15:30:00Z",
+                        "label": "lun 10 ago, 09:00",
+                        "dayLabel": "lunes 10 de agosto",
+                        "time": "09:00",
+                    },
+                ]
+            },
+        )
+    )
+    result = await runtime.execute("propose_slots", {})
+    assert [s["label"] for s in result["slots"]] == [
+        "hoy viernes 7 de agosto, 10:30",
+        "lunes 10 de agosto, 09:00",
+    ]
+    assert result["dias_con_agenda"] == [
+        "hoy viernes 7 de agosto",
+        "lunes 10 de agosto",
+    ]
+
+
+async def test_reschedule_mueve_la_cita_sin_handoff(runtime_y_ctx, respx_mock):
+    """Antes esto era handoff obligado y el lead se quedaba sin nadie."""
+    runtime, ctx, conv = runtime_y_ctx
+    patch = respx_mock.patch(f"{CRM_URL}/api/bot/bookings").mock(
+        return_value=httpx.Response(
+            200, json={"bookingId": "bk_1", "zoomJoinUrl": "https://meet.test/1"}
+        )
+    )
+    result = await runtime.execute(
+        "reschedule_session",
+        {"start_utc": SLOT_ISO, "dia_confirmado": "sí, el lunes 20"},
+    )
+    assert result["ok"] is True
+    assert result["label"] == "lunes 20 de julio, 10:00 am"
+    assert json.loads(patch.calls[0].request.content) == {
+        "conversationId": CRM_CONV_ID,
+        "startUtc": SLOT_ISO,
+    }
+    assert await ctx.store.get_offered_slots(conv.id) == []
+
+
+async def test_reschedule_rechaza_slot_no_ofrecido(runtime_y_ctx, respx_mock):
+    runtime, ctx, conv = runtime_y_ctx
+    patch = respx_mock.patch(f"{CRM_URL}/api/bot/bookings").mock(
+        return_value=httpx.Response(200, json={})
+    )
+    result = await runtime.execute(
+        "reschedule_session",
+        {"start_utc": "2026-07-20T17:00:00Z", "dia_confirmado": "el lunes"},
+    )
+    assert result["error"] == "slot_no_ofrecido"
+    assert patch.call_count == 0
+
+
+async def test_reschedule_sin_cita_manda_a_book(runtime_y_ctx, respx_mock):
+    runtime, ctx, conv = runtime_y_ctx
+    respx_mock.patch(f"{CRM_URL}/api/bot/bookings").mock(
+        return_value=httpx.Response(
+            404, json={"error": {"code": "no_booking", "message": "sin cita"}}
+        )
+    )
+    result = await runtime.execute(
+        "reschedule_session", {"start_utc": SLOT_ISO, "dia_confirmado": "el lunes"}
+    )
+    assert result["ok"] is False
+    assert result["error"] == "sin_cita"


### PR DESCRIPTION
Un lead pidió cita **"10:30, de mañana"**. Se le agendó **hoy** a las 10:30. Cuando corrigió ("mañana es sábado 8"), el agente hizo handoff y la conversación se murió ahí: IA pausada, cita mal puesta en pie, nadie del otro lado.

Tres causas, todas en este PR.

## 1. El agente solo podía ofrecer las citas más próximas, todas del mismo día

`propose_slots` pedía `limit=6` y el CRM devuelve los huecos ordenados por cercanía, así que los 6 se los comía el día de hoy. Con eso el agente no puede ofrecer otro día, ni respetar una preferencia ("después del mediodía"), ni darse cuenta de que el día que el lead pidió **no existe** en la agenda.

Ahora pide reparto (`perDay`, `days`), guarda un catálogo reservable más ancho — mostrar 3 es regla de discurso, no de datos — y recibe los días con agenda explícitos, para poder decir "ese día no hay agenda" en vez de mover al lead a otro día en silencio.

## 2. La etiqueta corta se presta a que lead y agente entiendan días distintos

`"vie 7 ago, 10:30"` no dice ni *hoy* ni *am/pm*. Basta que el lead conteste "10:30, de mañana" para que cada uno esté hablando de un día diferente.

Ahora el día va en palabras: `"hoy viernes 7 de agosto, 10:30"`, con fallback a la corta si el CRM no manda `dayLabel`.

## 3. Reagendar era handoff obligado

Nueva herramienta `reschedule_session` sobre `PATCH /api/bot/bookings`. Mover una cita ya no mata la conversación.

## Además

- `book_session` exige `dia_confirmado`: lo que el lead escribió para aceptar **ese** día. Si el modelo no puede citarlo, es que no hubo confirmación. El chasis obliga a nombrar el día completo y esperar un sí inequívoco — pero preguntando **una sola vez**, porque en pruebas se enganchó en un bucle de "¿seguro?".
- **Los 409 nunca se reconocían.** El cliente leía `{"code": ...}` y el CRM anida `{"error": {"code": ...}}`. En producción todo 409 caía como `conflict` genérico y el camino de `slot_taken` (re-ofrecer alternativas frescas) estaba muerto desde siempre. Los mocks usaban la forma plana, que es exactamente lo que lo escondía — ya usan la real.
- `strftime("%A %d de %B")` con el locale C de la imagen daba **"Friday 07 de August"**. Fechas en español a mano, y "hoy"/"mañana" resueltos por el sistema en vez de dejar que el modelo los calcule.

## Verificación

81/81 pytest. Verificado además contra un CRM real: el reparto devuelve 12 huecos en 4 días distintos donde antes daba 12 del mismo día; pedir un día sin agenda ya no crea reserva; una aceptación ambigua ya no reserva; y confirmar el día completo agenda el día correcto y luego lo mueve sin handoff.