### PR TITLE
Cerrar amable y dejar de responder cuando la conversación no va a ningún lado

### DIFF
--- a/app/db.py
+++ b/app/db.py
@@ -24,6 +24,7 @@ _CONV_COLUMNS = frozenset(
         "followup_due_at",
         "followup_sent",
         "last_inbound_at",
+        "stalled_at",
     }
 )
 
@@ -39,6 +40,7 @@ def _conv_from_row(row: asyncpg.Record) -> Conversation:
         followup_due_at=row["followup_due_at"],
         followup_sent=row["followup_sent"],
         last_inbound_at=row["last_inbound_at"],
+        stalled_at=row["stalled_at"],
     )
 
 
@@ -177,7 +179,8 @@ class PgStore:
                     UPDATE bot_conversation
                     SET phase = 'descubrimiento', greeted = FALSE,
                         media_notice_sent = FALSE, followup_due_at = NULL,
-                        followup_sent = FALSE, updated_at = now()
+                        followup_sent = FALSE, stalled_at = NULL,
+                        updated_at = now()
                     WHERE id = $1
                     """,
                     conversation_id,

--- a/app/stall.py
+++ b/app/stall.py
@@ -1,0 +1,91 @@
+"""Detector determinista de conversación que no va a ningún lado (candado de cierre).
+
+Por qué existe: hay hilos que se quedan dando vueltas — el lead contesta
+"ok", "va", un emoji, o sigue platicando sin soltar nada del negocio — y Nea
+seguía preguntando indefinidamente. Eso quema tokens, satura el inbox del
+dueño y, sobre todo, se lee a necesitado: un negocio serio no persigue.
+
+El conteo va aquí y no en el prompt por la misma razón que `hostility.py`:
+contar entre turnos es justo lo que un LLM hace de forma no confiable. El
+LLM solo pone la redacción del cierre; que el cierre OCURRA (y que después
+haya silencio) lo garantiza `turn.py`.
+
+Es deliberadamente conservador. Cerrarle a un lead vivo cuesta mucho más que
+aguantarle un turno de más, así que los dos disparadores exigen evidencia
+acumulada, no un mal mensaje suelto.
+"""
+from __future__ import annotations
+
+import re
+
+# Mensajes que no aportan nada: acuses, muletillas, risas, emojis sueltos.
+# Ojo con lo que NO está aquí: "no", "no me interesa", "ahorita no" — un "no"
+# es una respuesta clarísima y merece la salida elegante del prompt, no el
+# candado. Y cualquier cosa larga se asume con contenido.
+# Ojo con lo que tampoco está: los saludos. Un "hola" es una jugada legítima
+# de conversación, y contándolo como vacío se podía matar un hilo en el tercer
+# mensaje — demasiado pronto para un lead que apenas está entrando en calor.
+_RELLENO = re.compile(
+    r"^(ok(ay)?|oka|va|sale|ah|ajá|aja|mmm?|hmm?|eh|este|ya|bueno|"
+    r"gracias|grax|(?:ja|je|ji|ha){2,}|lol|:v|👍|👌|🙏|😂|🤣|🙂|😅"
+    r")[\s.!¡?¿,😀-🿿]*$",
+    re.I,
+)
+# Solo emojis/puntuación: tampoco aporta.
+_SIN_LETRAS = re.compile(r"^[^\w]+$", re.UNICODE)
+
+MAX_CARACTERES_VACIO = 24  # arriba de esto asumimos que dijo algo
+
+# Mensajes de relleno seguidos del lead que disparan el cierre.
+RACHA_VACIA = 3
+# Mensajes del lead sin que la conversación llegue nunca a agendar/DIY/handoff.
+MAX_MENSAJES_SIN_AVANCE = 14
+
+ALERTA = (
+    "ALERTA DEL SISTEMA (esto NO lo escribió el lead): esta conversación ya no "
+    "avanza. En ESTE turno tu respuesta es únicamente UNA línea cálida de "
+    "cierre que deja la puerta abierta — sin pregunta, sin pitch, sin "
+    "invitación a la cita, sin links. Algo del estilo de \"te dejo por aquí, "
+    "cuando quieras retomarlo me escribes y seguimos\". Despídete con dignidad: "
+    "no ruegues, no resumas la conversación y no ofrezcas nada más."
+)
+
+
+def es_relleno(text: str) -> bool:
+    """¿El mensaje del lead no aporta absolutamente nada?"""
+    limpio = (text or "").strip()
+    if not limpio:
+        return True
+    if len(limpio) > MAX_CARACTERES_VACIO:
+        return False
+    return bool(_RELLENO.match(limpio) or _SIN_LETRAS.match(limpio))
+
+
+def racha_vacia(user_texts: list[str]) -> int:
+    """Mensajes de relleno CONSECUTIVOS al final del hilo del lead.
+
+    Uno con contenido corta la racha: el lead que por fin soltó algo vuelve a
+    empezar de cero.
+    """
+    racha = 0
+    for text in reversed(user_texts):
+        if es_relleno(text):
+            racha += 1
+        else:
+            break
+    return racha
+
+
+def sin_rumbo(user_texts: list[str], fase: str) -> bool:
+    """¿Toca cerrar amable y dejar de responder?
+
+    Dos caminos, ambos con evidencia acumulada:
+    - el lead lleva `RACHA_VACIA` mensajes seguidos sin decir nada, o
+    - la conversación se estiró más de `MAX_MENSAJES_SIN_AVANCE` mensajes sin
+      salir nunca del descubrimiento (ni agendando, ni DIY, ni handoff).
+    """
+    if fase in ("agendando", "cerrada"):
+        return False  # ya hay rumbo: no es asunto del candado
+    if racha_vacia(user_texts) >= RACHA_VACIA:
+        return True
+    return len(user_texts) >= MAX_MENSAJES_SIN_AVANCE

--- a/app/state.py
+++ b/app/state.py
@@ -34,6 +34,9 @@ class Conversation:
     followup_due_at: datetime | None = None
     followup_sent: bool = False
     last_inbound_at: datetime | None = None
+    # Puesta cuando el agente cierra por conversación sin rumbo: mientras
+    # viva, el turno guarda silencio (ver app/stall.py).
+    stalled_at: datetime | None = None
 
 
 @dataclass
@@ -248,6 +251,7 @@ class MemoryStore:
         conv.media_notice_sent = False
         conv.followup_due_at = None
         conv.followup_sent = False
+        conv.stalled_at = None
 
     async def add_message(
         self,

--- a/app/turn.py
+++ b/app/turn.py
@@ -18,6 +18,7 @@ from app.config import canonical_identity
 from app.crm import CrmConflict, CrmError
 from app.hostility import ALERT as HOSTILITY_ALERT, hostile_streak
 from app.llm import LlmExhausted
+from app.stall import ALERTA as STALL_ALERT, racha_vacia, sin_rumbo
 from app.profile import resolve_profile
 from app.prompt import build_system_prompt
 from app.state import AppContext, InboundMessage, utcnow
@@ -26,6 +27,11 @@ from app.tools import TOOL_SCHEMAS, ToolRuntime
 logger = logging.getLogger("nea.turn")
 
 MAX_TOOL_ROUNDS = 5
+# Cuánto calla el agente tras cerrar por falta de rumbo. Un lead que vuelve al
+# día siguiente merece respuesta; el que insiste en el mismo hilo muerto, no.
+STALL_COOLDOWN = timedelta(hours=24)
+# Mensajes que se traen para contar el hilo del lead (el LLM ve menos).
+STALL_LOOKBACK = 40
 CONTEXT_ATTEMPTS = 3  # el relay puede tardar un instante en aterrizar en el CRM
 
 # Comando de pruebas: reinicia la memoria de ESA conversación. Disponible SOLO
@@ -73,6 +79,23 @@ async def run_turn(
     ):
         await _run_reset(ctx, conv, identity)
         return
+
+    # --- Gate 1.5: conversación ya cerrada por no ir a ningún lado --------
+    # El agente ya se despidió amable; seguir contestando es perseguir. Se
+    # reabre sola tras el enfriamiento (un lead que vuelve al día siguiente
+    # merece respuesta) o cuando el dueño reactiva la IA desde el CRM.
+    if conv.stalled_at is not None:
+        if utcnow() - conv.stalled_at < STALL_COOLDOWN:
+            logger.info(
+                "turno %s: conversación cerrada por falta de rumbo — silencio",
+                identity,
+            )
+            return
+        logger.info(
+            "turno %s: el lead volvió tras el enfriamiento — reabro", identity
+        )
+        await ctx.store.update_conversation(conv.id, stalled_at=None)
+        conv.stalled_at = None
 
     # --- Gate 2: contexto del CRM (aiEnabled, ventana) --------------------
     context = await _fetch_context(ctx, identity)
@@ -140,7 +163,10 @@ async def run_turn(
         offered=offered,
         tz=_agent_tz(settings),
     )
-    history = await ctx.store.recent_messages(conv.id, settings.history_window)
+    # Se traen más mensajes de los que ve el LLM: el candado de cierre cuenta
+    # el hilo COMPLETO del lead, no solo la ventana de contexto.
+    recientes = await ctx.store.recent_messages(conv.id, STALL_LOOKBACK)
+    history = recientes[-settings.history_window :]
     messages: list[dict[str, Any]] = [{"role": "system", "content": system}] + [
         {"role": m.role, "content": m.content} for m in history
     ]
@@ -150,6 +176,19 @@ async def run_turn(
     streak = hostile_streak([m.content for m in history if m.role == "user"])
     if streak >= 3:
         messages.append({"role": "system", "content": HOSTILITY_ALERT})
+    # Candado de cierre: conversación que no va a ningún lado. Se despide con
+    # UNA línea cálida en este turno y después calla (gate 1.5). El conteo es
+    # determinista aquí; el LLM solo pone la redacción.
+    del_lead = [m.content for m in recientes if m.role == "user"]
+    cerrar_sin_rumbo = streak < 3 and sin_rumbo(del_lead, conv.phase)
+    if cerrar_sin_rumbo:
+        logger.info(
+            "turno %s: sin rumbo (%d mensajes del lead, racha vacía %d) — cierro",
+            identity,
+            len(del_lead),
+            racha_vacia(del_lead),
+        )
+        messages.append({"role": "system", "content": STALL_ALERT})
     if image_uris:
         # El último user message de este turno se vuelve multimodal: el
         # historial persiste solo el texto; las imágenes viven en ESTE turno.
@@ -193,7 +232,13 @@ async def run_turn(
 
     # --- Fase + seguimiento -----------------------------------------------
     updates: dict[str, Any] = {"greeted": True}
-    if runtime.handoff_reason is not None or runtime.booked or runtime.routed_out:
+    if cerrar_sin_rumbo:
+        # Se marca aunque el envío haya fallado: la decisión de cerrar ya se
+        # tomó y no queremos que el próximo mensaje reabra el ciclo.
+        updates["stalled_at"] = utcnow()
+        updates["phase"] = "cerrada"
+        updates["followup_due_at"] = None
+    elif runtime.handoff_reason is not None or runtime.booked or runtime.routed_out:
         updates["phase"] = "cerrada"
         updates["followup_due_at"] = None
     else:

--- a/app/webhook.py
+++ b/app/webhook.py
@@ -251,6 +251,10 @@ async def _early_typing(ctx: AppContext, identity: str) -> None:
         conv = await ctx.store.get_or_create_conversation(identity)
         if not conv.crm_conversation_id:
             return
+        # Conversación ya cerrada por falta de rumbo: no va a haber respuesta,
+        # así que un "escribiendo…" sería justo la mentira que este gate evita.
+        if conv.stalled_at is not None:
+            return
         await ctx.crm.post_typing(str(conv.crm_conversation_id))
     except Exception as exc:
         logger.debug("typing temprano de %s falló (%s) — sigo", identity, exc)

--- a/migrations/003_stalled.sql
+++ b/migrations/003_stalled.sql
@@ -1,0 +1,7 @@
+-- 003_stalled.sql — candado de cierre: marca de cuándo el agente cerró la
+-- conversación por no ir a ningún lado. Mientras esté puesta, el agente no
+-- responde (se reabre sola si el lead vuelve tras el periodo de enfriamiento
+-- o si el dueño reactiva la IA desde el CRM). Idempotente.
+
+ALTER TABLE bot_conversation
+  ADD COLUMN IF NOT EXISTS stalled_at TIMESTAMPTZ;

--- a/tests/test_stall.py
+++ b/tests/test_stall.py
@@ -1,0 +1,156 @@
+"""Candado de cierre: conversación que no va a ningún lado.
+
+El agente se despide amable UNA vez y después calla. El conteo es determinista
+(app/stall.py); aquí se fija tanto el detector como el silencio posterior.
+"""
+from __future__ import annotations
+
+import asyncio
+from datetime import timedelta
+
+import pytest
+
+from app import turn
+from app.stall import es_relleno, racha_vacia, sin_rumbo
+from app.state import utcnow
+from tests.conftest import IDENTITY, mock_crm_basics, wa_body
+
+
+# ------------------------------------------------------------- detector ---
+
+
+@pytest.mark.parametrize(
+    "texto",
+    ["ok", "va", "ajá", "jaja", "jajaja", "jejeje", "👍", "🙏🙏", "  ", "Gracias"],
+)
+def test_relleno_no_aporta(texto):
+    assert es_relleno(texto) is True
+
+
+@pytest.mark.parametrize(
+    "texto",
+    [
+        "tengo una clínica dental",
+        "no me interesa",  # un "no" es una respuesta clarísima, no relleno
+        "ahorita no puedo, la otra semana",
+        "somos 12",
+        "ok pero cuánto cuesta",
+        "hola",  # un saludo es jugada legítima, no vacío
+        "buenas tardes",
+    ],
+)
+def test_contenido_real_no_es_relleno(texto):
+    assert es_relleno(texto) is False
+
+
+def test_un_mensaje_con_contenido_corta_la_racha():
+    assert racha_vacia(["ok", "va", "tengo una taquería", "ok"]) == 1
+    assert racha_vacia(["tengo una taquería", "ok", "va", "ajá"]) == 3
+
+
+def test_sin_rumbo_por_racha_de_vacios():
+    assert sin_rumbo(["hola", "ok", "va", "ajá"], "descubrimiento") is True
+    # Dos seguidos no bastan: el saludo NO cuenta como vacío.
+    assert sin_rumbo(["hola", "ok", "va"], "descubrimiento") is False
+
+
+def test_sin_rumbo_por_conversacion_larga_sin_avance():
+    largos = [f"mensaje con contenido numero {i}" for i in range(14)]
+    assert sin_rumbo(largos, "descubrimiento") is True
+
+
+def test_agendando_nunca_se_cierra_por_el_candado():
+    """Ya hay rumbo: el candado no se mete aunque el lead conteste corto."""
+    assert sin_rumbo(["ok", "va", "ajá"], "agendando") is False
+    assert sin_rumbo([f"m{i}" * 10 for i in range(20)], "cerrada") is False
+
+
+# ----------------------------------------------------------- en el turno ---
+
+
+async def _tres_vacios(ctx, client):
+    for i, texto in enumerate(("ok", "va", "ajá")):
+        await client.post(
+            "/webhook", content=wa_body(text=texto, wamid=f"wamid.v{i}")
+        )
+        await asyncio.sleep(0.35)
+
+
+async def test_cierra_una_vez_y_despues_calla(ctx, client, respx_mock):
+    routes = mock_crm_basics(respx_mock)
+    conv = await ctx.store.get_or_create_conversation(IDENTITY)
+    await _tres_vacios(ctx, client)
+
+    # Se despidió en el tercero (uno por mensaje: 3 respuestas).
+    assert routes["messages"].call_count == 3
+    marcada = (await ctx.store.get_or_create_conversation(IDENTITY)).stalled_at
+    assert marcada is not None
+
+    # El alertazo de cierre viajó en el turno del cierre, no antes.
+    sistemas = [
+        m["content"]
+        for m in ctx.llm.calls[-1]["messages"]
+        if m["role"] == "system"
+    ]
+    assert any("UNA línea cálida de cierre" in s for s in sistemas)
+
+    # Y a partir de aquí, silencio: ni LLM ni envío.
+    llamadas_previas = len(ctx.llm.calls)
+    await client.post("/webhook", content=wa_body(text="oye", wamid="wamid.v9"))
+    await asyncio.sleep(0.35)
+    assert routes["messages"].call_count == 3
+    assert len(ctx.llm.calls) == llamadas_previas
+
+
+async def test_el_lead_que_vuelve_tras_el_enfriamiento_reabre(
+    ctx, client, respx_mock
+):
+    routes = mock_crm_basics(respx_mock)
+    conv = await ctx.store.get_or_create_conversation(IDENTITY)
+    await ctx.store.update_conversation(
+        conv.id,
+        crm_conversation_id="cv_test1",
+        stalled_at=utcnow() - turn.STALL_COOLDOWN - timedelta(minutes=1),
+    )
+
+    await client.post(
+        "/webhook", content=wa_body(text="oye, ya lo pensé mejor", wamid="wamid.r1")
+    )
+    await asyncio.sleep(0.35)
+
+    assert routes["messages"].call_count == 1  # volvió a atenderlo
+    assert (await ctx.store.get_or_create_conversation(IDENTITY)).stalled_at is None
+
+
+async def test_el_candado_no_pisa_el_handoff_por_hostilidad(
+    ctx, client, respx_mock
+):
+    """Tres groserías seguidas son cortas y podrían leerse como "relleno": el
+    handoff por hostilidad manda, porque el dueño tiene que ver esa conversación."""
+    routes = mock_crm_basics(respx_mock)
+    for i, texto in enumerate(("son unos rateros", "puro humo", "pinches estafadores")):
+        await client.post(
+            "/webhook", content=wa_body(text=texto, wamid=f"wamid.h{i}")
+        )
+        await asyncio.sleep(0.35)
+
+    assert routes["handoff"].call_count == 1
+    assert (await ctx.store.get_or_create_conversation(IDENTITY)).stalled_at is None
+
+
+async def test_no_manda_escribiendo_a_una_conversacion_cerrada(
+    ctx, client, respx_mock
+):
+    """Un "escribiendo…" seguido de silencio es peor que el silencio solo."""
+    routes = mock_crm_basics(respx_mock)
+    conv = await ctx.store.get_or_create_conversation(IDENTITY)
+    await ctx.store.update_conversation(
+        conv.id, crm_conversation_id="cv_test1", stalled_at=utcnow()
+    )
+    previos = routes["typing"].call_count
+
+    await client.post("/webhook", content=wa_body(text="sigues ahi?", wamid="wamid.t1"))
+    await asyncio.sleep(0.35)
+
+    assert routes["typing"].call_count == previos
+    assert routes["messages"].call_count == 0


### PR DESCRIPTION
Hay hilos que se quedan dando vueltas: el lead contesta "ok", "va", un emoji, o sigue platicando sin soltar nada del negocio, y el agente sigue preguntando indefinidamente. Eso quema tokens, satura el inbox del dueño y sobre todo se lee a necesitado.

## Diseño

`app/stall.py` sigue el patrón que ya usa `hostility.py`: **contar entre turnos es justo lo que un LLM hace mal**, así que el conteo es determinista en Python y el LLM solo pone la redacción de la despedida. Que el cierre ocurra lo garantiza `turn.py`.

Dos disparadores, ambos conservadores a propósito — cerrarle a un lead vivo cuesta mucho más que aguantar un turno de más:

- **3 mensajes seguidos sin contenido.** Uno con contenido corta la racha.
- **14 mensajes del lead** sin que la conversación salga nunca del descubrimiento.

Detalle que costó una iteración: al principio conté los saludos como relleno, y eso permitía matar un hilo en el **tercer** mensaje. Un "hola" es una jugada legítima de conversación, así que quedó fuera del léxico.

El candado no se mete si ya hay rumbo (`agendando`/`cerrada`), y el handoff por hostilidad le gana — esa conversación el dueño tiene que verla, no cerrarla en silencio.

## Después de cerrar

Silencio, y **se reabre sola a las 24 h**: quien vuelve al día siguiente merece respuesta. También se reabre si el dueño reactiva la IA desde el CRM.

Incluye no mandar "escribiendo…" a una conversación ya cerrada. Salió en una prueba en vivo: el candado callaba bien pero el typing seguía saliendo, así que el lead veía al agente escribiendo y después nada — que es justo la mentira que ese gate existe para evitar.

## Verificación

102/102 pytest. Verificado también en vivo por WhatsApp:

```
sin rumbo (4 mensajes del lead, racha vacía 3) — cierro
→ despedida enviada
[mensaje nuevo del lead]
conversación cerrada por falta de rumbo — silencio   ← sin llamada al LLM, sin envío
```

Y la despedida quedó en el tono buscado: *"Te dejo por aquí; cuando quieras retomarlo, me escribes y seguimos 👍"*.