### PR TITLE
Separar la lista de testers de la allowlist de respuesta

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -61,6 +61,13 @@ HISTORY_WINDOW=10
 # salir a producción — decisión explícita del dueño.
 ALLOWED_WA_IDS=REEMPLAZA_5215512345678
 
+# Quien puede usar el comando /reset (borra la memoria de SU conversacion).
+# Va aparte de ALLOWED_WA_IDS a proposito: en produccion esa lista va vacia
+# para atender a todos los leads, y colgar el /reset de ella dejaba el
+# comando muerto justo donde hace falta para una ronda de pruebas en vivo.
+# Vacia = comando apagado. CSV de identidades, misma forma que arriba.
+TESTER_WA_IDS=
+
 # Segundos de coalescencia: una ráfaga de mensajitos = UNA respuesta.
 COALESCE_SECONDS=4
 

--- a/README.md
+++ b/README.md
@@ -88,9 +88,12 @@ y el dominio del webhook hacia el puerto 8000.
 - **Allowlist de pruebas**: con `ALLOWED_WA_IDS` poblada, Nea solo responde a
   esas identidades (todo lo demás se releva al CRM sin respuesta). Vacíala
   únicamente para salir a producción.
-- **Comando `/reset`**: desde una línea de la allowlist, reinicia la memoria
-  de esa conversación (ficha limpia, IA reactivada) — cada prueba arranca con
-  un lead virgen.
+- **Comando `/reset`**: desde una línea listada en `TESTER_WA_IDS`, reinicia
+  la memoria de esa conversación (ficha limpia, IA reactivada) — cada prueba
+  arranca con un lead virgen. Es una variable aparte de `ALLOWED_WA_IDS` a
+  propósito: en producción la allowlist va vacía para atender a todos los
+  leads, y si el comando colgara de ella no habría forma de resetear sin
+  dejar de atenderlos.
 - `selftest/evolution.py` es un harness opcional para mandar WhatsApp reales
   desde una línea tester vía [Evolution API](https://doc.evolution-api.com/),
   con pausas mínimas, tope de mensajes y kill-switch de archivo.

--- a/app/config.py
+++ b/app/config.py
@@ -48,7 +48,13 @@ class Settings(BaseSettings):
     history_window: int = 10
 
     # Guardarraíles y tiempos
-    allowed_wa_ids: str = ""  # CSV; vacía = responde a todos (Constitución V)
+    allowed_wa_ids: str = ""
+    # Identidades que pueden usar el comando /reset. Va SEPARADA de
+    # allowed_wa_ids a propósito: en producción esa lista va vacía (el agente
+    # atiende a todos los leads), y cuando el /reset colgaba de ella el
+    # comando quedaba muerto justo donde hace falta — para correr una ronda
+    # de pruebas en vivo había que cerrarle la puerta a los leads reales.
+    tester_wa_ids: str = ""  # CSV; vacía = responde a todos (Constitución V)
     coalesce_seconds: float = 4.0
     followup_hours: float = 4.0
     # "Escribiendo…" casi inmediato al recibir un mensaje (antes del coalesce).
@@ -62,11 +68,18 @@ class Settings(BaseSettings):
     # capturar los formatos reales de Meta (spec 002). Apagar al terminar.
     capture_payloads: bool = False
 
+    @staticmethod
+    def _identities(csv: str) -> frozenset[str]:
+        return frozenset(
+            canonical_identity(part) for part in csv.split(",") if part.strip()
+        )
+
     @property
     def allowed_identities(self) -> frozenset[str]:
         """Allowlist canonicalizada; vacía = sin restricción."""
-        return frozenset(
-            canonical_identity(part)
-            for part in self.allowed_wa_ids.split(",")
-            if part.strip()
-        )
+        return self._identities(self.allowed_wa_ids)
+
+    @property
+    def tester_identities(self) -> frozenset[str]:
+        """Quién puede correr /reset. Vacía = comando apagado."""
+        return self._identities(self.tester_wa_ids)

--- a/app/turn.py
+++ b/app/turn.py
@@ -29,7 +29,7 @@ MAX_TOOL_ROUNDS = 5
 CONTEXT_ATTEMPTS = 3  # el relay puede tardar un instante en aterrizar en el CRM
 
 # Comando de pruebas: reinicia la memoria de ESA conversación. Disponible SOLO
-# para identidades de ALLOWED_WA_IDS — con la allowlist vacía queda apagado.
+# para identidades de TESTER_WA_IDS (vacía = comando apagado).
 RESET_COMMANDS = frozenset({"/reset", "#reset"})
 
 
@@ -68,7 +68,7 @@ async def run_turn(
     # --- Comando /reset (líneas de prueba) --------------------------------
     # Corre ANTES de los gates de aiEnabled/ventana: un reset también debe
     # sacar la conversación de un handoff activo.
-    if canonical_identity(identity) in allowed and any(
+    if canonical_identity(identity) in settings.tester_identities and any(
         (m.text or "").strip().lower() in RESET_COMMANDS for m in inbound
     ):
         await _run_reset(ctx, conv, identity)

--- a/tests/test_webhook.py
+++ b/tests/test_webhook.py
@@ -382,7 +382,7 @@ async def test_reaccion_no_abre_turno(ctx, client, respx_mock):
 
 
 async def test_reset_de_linea_de_pruebas_borra_memoria(respx_mock):
-    settings = make_settings(allowed_wa_ids=IDENTITY)
+    settings = make_settings(tester_wa_ids=IDENTITY)
     ctx = make_ctx(settings)
     routes = mock_crm_basics(respx_mock)
     reset_route = respx_mock.post(f"{CRM_URL}/api/bot/reset").mock(
@@ -410,14 +410,14 @@ async def test_reset_de_linea_de_pruebas_borra_memoria(respx_mock):
     assert routes["messages"].call_count == 1  # confirmación al tester
 
 
-async def test_reset_sin_allowlist_es_texto_normal(ctx, client, respx_mock):
+async def test_reset_sin_lista_de_testers_es_texto_normal(ctx, client, respx_mock):
     routes = mock_crm_basics(respx_mock)
     reset_route = respx_mock.post(f"{CRM_URL}/api/bot/reset").mock(
         return_value=httpx.Response(200, json={"ok": True})
     )
     await client.post("/webhook", content=wa_body(text="/reset", wamid="wamid.rst2"))
     await asyncio.sleep(0.3)
-    assert reset_route.call_count == 0  # con la allowlist vacía no hay comando
+    assert reset_route.call_count == 0  # sin TESTER_WA_IDS no hay comando
     assert len(ctx.llm.calls) == 1  # se trató como un mensaje cualquiera
     assert routes["messages"].call_count == 1
 
@@ -434,3 +434,22 @@ async def test_media_caida_degrada_honesto(ctx, client, respx_mock):
         if m["role"] == "user"
     )
     assert "NO pudiste abrir" in user_texts  # marcador honesto
+
+
+async def test_reset_no_depende_de_la_allowlist_de_respuesta(respx_mock):
+    """En produccion ALLOWED_WA_IDS va vacia (el agente atiende a todos).
+    Cuando el /reset colgaba de ella, el comando quedaba muerto justo donde
+    hace falta: para usarlo habia que dejar de atender a los leads reales."""
+    ctx = make_ctx(make_settings(allowed_wa_ids="", tester_wa_ids=IDENTITY))
+    mock_crm_basics(respx_mock)
+    reset_route = respx_mock.post(f"{CRM_URL}/api/bot/reset").mock(
+        return_value=httpx.Response(200, json={"ok": True})
+    )
+    app = create_app(ctx=ctx)
+    transport = httpx.ASGITransport(app=app)
+    async with httpx.AsyncClient(transport=transport, base_url="http://bot.test") as c:
+        await c.post("/webhook", content=wa_body(text="/reset", wamid="wamid.rst3"))
+        await asyncio.sleep(0.3)
+    await ctx.crm.aclose()
+    assert reset_route.call_count == 1
+    assert len(ctx.llm.calls) == 0


### PR DESCRIPTION
El comando `/reset` colgaba de `ALLOWED_WA_IDS`, que es la lista de *a quién le respondo*.

En producción esa lista va **vacía** (el agente atiende a todos los leads), y con la lista vacía `identity in allowed` es siempre falso. O sea: **el comando de pruebas está muerto exactamente donde hace falta**. Para usarlo había que poner un valor en `ALLOWED_WA_IDS` — es decir, dejar de atender a los leads reales mientras dura la prueba.

Lo descubrí al intentar correr una ronda de verificación en vivo sobre producción: no había forma de resetear la conversación sin apagarle la puerta a todo el mundo.

## Qué cambia

`TESTER_WA_IDS` es su propia variable (vacía = comando apagado). Las dos decisiones quedan independientes: a quién respondo, y quién puede resetear su conversación.

## Verificación

78/78 pytest, con un test que fija justo el caso que estaba roto: allowlist vacía + tester listado → el `/reset` funciona. Probado además en producción con la allowlist vacía; el reset se ejecutó sin tocarla.