### PR TITLE
fix: el 409 del CRM viene anidado, y por eso slot_taken nunca se activaba

### DIFF
--- a/app/crm.py
+++ b/app/crm.py
@@ -42,11 +42,28 @@ class SlotTaken(CrmConflict):
         self.slots: list[dict[str, Any]] = list((payload or {}).get("slots") or [])
 
 
-def _conflict_code(response: httpx.Response) -> str:
+def _payload(response: httpx.Response) -> dict[str, Any]:
     try:
-        return str(response.json().get("code") or "conflict")
+        data = response.json()
     except Exception:
-        return "conflict"
+        return {}
+    return data if isinstance(data, dict) else {}
+
+
+def _conflict_code(response: httpx.Response) -> str:
+    """Código tipado de un 409, tolerando las dos formas del cuerpo.
+
+    El CRM anida SIEMPRE `{"error": {"code": ...}}` (lib/api.ts::apiError); la
+    forma plana `{"code": ...}` solo existía en los mocks viejos de estos
+    tests. Leyendo únicamente la raíz, en producción TODO 409 se degradaba a
+    "conflict" genérico y el camino de `slot_taken` —re-ofrecer alternativas
+    frescas— nunca se activaba. Se toleran ambas.
+    """
+    payload = _payload(response)
+    nested = payload.get("error")
+    if isinstance(nested, dict) and nested.get("code"):
+        return str(nested["code"])
+    return str(payload.get("code") or "conflict")
 
 
 # Catálogo cerrado del CRM para handoff.reason (006). El LLM escribe motivos
@@ -168,14 +185,11 @@ class CrmClient:
             json={"conversationId": conversation_id, "startUtc": start_utc},
         )
         if resp.status_code == 409:
-            payload: dict[str, Any] = {}
-            try:
-                payload = resp.json()
-            except Exception:
-                pass
-            if payload.get("code") == "slot_taken":
+            payload = _payload(resp)
+            code = _conflict_code(resp)
+            if code == "slot_taken":
                 raise SlotTaken(payload)
-            raise CrmConflict(_conflict_code(resp), payload)
+            raise CrmConflict(code, payload)
         # El CRM real responde 201 Created (REST); los mocks viejos daban 200.
         if resp.status_code not in (200, 201):
             raise CrmError(f"bookings devolvió {resp.status_code}")

--- a/app/tools.py
+++ b/app/tools.py
@@ -274,7 +274,10 @@ class ToolRuntime:
         return {
             "ok": True,
             "label": result.get("label") or chosen.label,
-            "zoom_url": result.get("zoomJoinUrl"),
+            # `joinUrl` es el nombre del contrato; `zoomJoinUrl` es el alias
+            # histórico del CRM. El agente no debe casarse con un proveedor de
+            # videollamada concreto.
+            "zoom_url": result.get("joinUrl") or result.get("zoomJoinUrl"),
             "instrucciones": (
                 "confirma día y hora de la cita, comparte el link de la "
                 "videollamada si existe y menciona lo que el negocio pida "

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -84,8 +84,17 @@ async def test_book_slot_taken_ofrece_alternativas_frescas(runtime_y_ctx, respx_
         {"startUtc": "2026-07-21T16:00:00Z", "endUtc": None, "label": "martes 21, 10:00 am"},
         {"startUtc": "2026-07-21T17:00:00Z", "endUtc": None, "label": "martes 21, 11:00 am"},
     ]
+    # Forma REAL del CRM: el código va ANIDADO bajo `error` (lib/api.ts).
+    # El mock viejo lo ponía en la raíz y por eso este test pasaba mientras en
+    # producción el slot_taken nunca se activaba.
     respx_mock.post(f"{CRM_URL}/api/bot/bookings").mock(
-        return_value=httpx.Response(409, json={"code": "slot_taken", "slots": frescos})
+        return_value=httpx.Response(
+            409,
+            json={
+                "error": {"code": "slot_taken", "message": "ese horario ya se ocupó"},
+                "slots": frescos,
+            },
+        )
     )
     result = await runtime.execute("book_session", {"start_utc": SLOT_ISO})
     assert result["ok"] is False
@@ -95,6 +104,44 @@ async def test_book_slot_taken_ofrece_alternativas_frescas(runtime_y_ctx, respx_
     offered = await ctx.store.get_offered_slots(conv.id)
     assert [s.label for s in offered] == [s["label"] for s in frescos]
     assert runtime.booked is False
+
+
+async def test_book_slot_taken_tambien_con_el_codigo_en_la_raiz(
+    runtime_y_ctx, respx_mock
+):
+    """Compatibilidad: un CRM que emita el código plano sigue funcionando."""
+    runtime, ctx, conv = runtime_y_ctx
+    frescos = [
+        {"startUtc": "2026-07-21T16:00:00Z", "endUtc": None, "label": "martes 21, 10:00 am"},
+    ]
+    respx_mock.post(f"{CRM_URL}/api/bot/bookings").mock(
+        return_value=httpx.Response(409, json={"code": "slot_taken", "slots": frescos})
+    )
+    result = await runtime.execute("book_session", {"start_utc": SLOT_ISO})
+    assert result["ok"] is False
+    assert result["error"] == "slot_taken"
+    assert [s["label"] for s in result["slots"]] == [s["label"] for s in frescos]
+
+
+async def test_book_devuelve_join_url_del_contrato(runtime_y_ctx, respx_mock):
+    """El agente no se casa con un proveedor: `joinUrl` es el nombre del contrato."""
+    runtime, ctx, conv = runtime_y_ctx
+    respx_mock.post(f"{CRM_URL}/api/bot/bookings").mock(
+        return_value=httpx.Response(
+            201,
+            json={
+                "bookingId": "bk_1",
+                "label": "martes 21, 10:00 am",
+                "joinUrl": "https://reunion.ejemplo.com/abc",
+            },
+        )
+    )
+    respx_mock.put(f"{CRM_URL}/api/bot/ficha").mock(
+        return_value=httpx.Response(200, json={"ficha": {}})
+    )
+    result = await runtime.execute("book_session", {"start_utc": SLOT_ISO})
+    assert result["ok"] is True
+    assert result["zoom_url"] == "https://reunion.ejemplo.com/abc"
 
 
 async def test_propose_slots_maximo_3_y_persistidos(runtime_y_ctx, respx_mock):


### PR DESCRIPTION
Un bug de producción que llevaba semanas escondido detrás de un mock.

## Qué pasaba

El CRM envuelve **siempre** sus errores como `{"error": {"code": ...}}`
(`lib/api.ts::apiError`). El agente leía `code` en la **raíz**:

```python
return str(response.json().get("code") or "conflict")
```

Resultado: en producción, **todo 409 se degradaba a `"conflict"` genérico**. El
caso que importa es `slot_taken` — cuando un hueco se ocupa entre que el agente
lo ofrece y el lead lo confirma. El CRM manda en esa misma respuesta las
alternativas frescas para re-ofrecer sin otra ida y vuelta, y el agente las
tiraba: levantaba un conflicto genérico y el lead recibía un "no pude completar
la acción" en lugar de dos horarios nuevos.

`create_booking` además decidía por su cuenta mirando la raíz
(`payload.get("code") == "slot_taken"`), así que arreglar solo el helper no
bastaba.

## Qué lo escondía

El mock del test respondía con el código plano:

```python
httpx.Response(409, json={"code": "slot_taken", "slots": frescos})
```

Esa forma **no la emite ningún CRM** — solo existió en los mocks viejos. El test
pasaba en verde mientras el camino real nunca se ejecutaba. Queda corregido a la
forma real (anidada), y se agrega uno con la forma plana para no romper a quien
la emita.

## Qué cambia

- `_conflict_code` tolera las dos formas, con `_payload` como helper que
  sobrevive a un cuerpo que no sea JSON o que no sea un objeto.
- `create_booking` decide con esa función en vez de leer la raíz por su cuenta.
- `book_session` lee `joinUrl` con `zoomJoinUrl` como alias histórico:
  `joinUrl` es el nombre del contrato publicado del CRM, y el agente no debe
  casarse con un proveedor de videollamada concreto.

## Verificación

79 pruebas en verde. Y las dos nuevas se probaron **en rojo** contra el código
anterior antes de darlas por buenas — que es justamente lo que no se hizo la
primera vez:

```
FAILED tests/test_tools.py::test_book_slot_taken_ofrece_alternativas_frescas
FAILED tests/test_tools.py::test_book_devuelve_join_url_del_contrato
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
