### PR TITLE
fix: acoplar el agendamiento al motor de agenda de Vocero

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -34,6 +34,16 @@ idempotentes al arranque · httpx (CRM y OpenAI) · pytest + respx · Docker
   vacíes sin decisión explícita del dueño de la instancia.
 - **Degradación silenciosa**: LLM/CRM fallando jamás rompe el webhook ni manda
   texto roto; tras reintentos → silencio + handoff `error`.
+- **La agenda la manda el CRM.** Vocero registra la oferta contra la
+  conversación (por eso `conversationId` va SIEMPRE en `get_availability`) y
+  decide qué es reservable. `offered_slots` de Nea es un ESPEJO: sirve para
+  etiquetar con el día en palabras y frenar alucinaciones antes del viaje de
+  red. Si el CRM responde `slot_not_offered`, su lista gana y el espejo se
+  resincroniza — no se discute.
+- **La agenda puede no existir.** En Vocero va detrás de la bandera `AGENDA`,
+  apagada por defecto: esos endpoints responden 404. Se sondea al arrancar
+  (`crm.agenda_available()`); sin agenda no se le enseñan al modelo las
+  herramientas de agendar y el prompt se lo dice.
 
 ## Definición de Hecho
 

--- a/README.md
+++ b/README.md
@@ -66,6 +66,12 @@ Requisitos: Python 3.11+, Postgres propio (no el del CRM), una instancia de
 Vocero CRM con el bot gateway habilitado (`BOT_API_KEY`), y una app de Meta
 con WhatsApp Cloud API apuntando su webhook a este servicio.
 
+**Si quieres que Nea agende, enciende el motor de agenda de Vocero**
+(`AGENDA=on` en el CRM): viene apagado por defecto. Nea lo detecta al arrancar
+— contra un CRM sin agenda no ofrece horarios ni promete citas, califica y
+escala a un humano. La agenda la lleva el CRM: Nea le pide los huecos, él
+registra lo ofrecido y solo acepta reservar uno de esos.
+
 ```bash
 git clone https://github.com/kevinrivm/nea-agent && cd nea-agent
 python -m venv .venv && . .venv/bin/activate   # Windows: .venv\Scripts\activate

--- a/app/crm.py
+++ b/app/crm.py
@@ -6,7 +6,10 @@ Endpoints:
   POST /api/bot/messages   {conversationId, text}   → 409 ai_paused|window_closed
   PUT  /api/bot/ficha      {conversationId, ficha}
   POST /api/bot/handoff    {conversationId, reason}
-  GET  /api/bot/availability?limit=&perDay=&days=   → huecos repartidos por día
+  GET  /api/bot/availability?conversationId=&limit=&perDay=&days=
+                                                    → huecos repartidos por día,
+                                                      REGISTRADOS como la oferta
+                                                      de esa conversación
   POST /api/bot/bookings   {conversationId, startUtc} → 409 slot_taken + slots frescos
   PATCH /api/bot/bookings  {conversationId, startUtc} → mueve la próxima cita
   GET  /api/bot/media/{mediaId}                       → binario + content-type
@@ -35,12 +38,42 @@ class CrmConflict(CrmError):
         self.payload = payload or {}
 
 
-class SlotTaken(CrmConflict):
+class AgendaUnavailable(CrmError):
+    """El CRM no tiene agenda (404 en `/api/bot/availability|bookings`).
+
+    Vocero trae el motor de agendamiento detrás de una bandera de despliegue
+    (`AGENDA`) y viene APAGADA por defecto: en una instancia así esos endpoints
+    no existen. No es una caída ni un error de configuración de Nea — es una
+    capacidad que ese CRM no ofrece, y el agente tiene que dejar de prometer
+    citas en vez de reintentar contra una puerta que no está.
+    """
+
+
+class ConflictWithSlots(CrmConflict):
+    """409 de agenda que viene con horarios para volver a ofrecer."""
+
+    def __init__(self, code: str, payload: dict[str, Any] | None = None) -> None:
+        super().__init__(code, payload)
+        self.slots: list[dict[str, Any]] = list((payload or {}).get("slots") or [])
+
+
+class SlotTaken(ConflictWithSlots):
     """El slot se ocupó entre oferta y confirmación; trae alternativas frescas."""
 
     def __init__(self, payload: dict[str, Any] | None = None) -> None:
         super().__init__("slot_taken", payload)
-        self.slots: list[dict[str, Any]] = list((payload or {}).get("slots") or [])
+
+
+class SlotNotOffered(ConflictWithSlots):
+    """El CRM no reconoce ese horario como ofrecido A ESTA conversación.
+
+    Desde que Vocero bajó la garantía "solo se reserva lo que se ofreció" a su
+    propio núcleo, la lista que manda aquí es la AUTORIDAD: si no coincide con
+    la que tiene Nea, la de Nea está vieja y hay que resincronizar con esta.
+    """
+
+    def __init__(self, payload: dict[str, Any] | None = None) -> None:
+        super().__init__("slot_not_offered", payload)
 
 
 def _payload(response: httpx.Response) -> dict[str, Any]:
@@ -72,6 +105,8 @@ def _booking_conflict(response: httpx.Response) -> CrmConflict:
     code = _conflict_code(response)
     if code == "slot_taken":
         return SlotTaken(payload)
+    if code == "slot_not_offered":
+        return SlotNotOffered(payload)
     return CrmConflict(code, payload)
 
 
@@ -178,23 +213,57 @@ class CrmClient:
 
     async def get_availability(
         self,
+        conversation_id: str,
         limit: int = 6,
         per_day: int | None = None,
         days: int | None = None,
     ) -> list[dict[str, Any]]:
-        """Huecos libres. Con `per_day` el CRM los reparte entre días distintos
-        (si no, los primeros N se los come el día de hoy) y los devuelve con el
-        día desambiguado en `dayLabel`."""
-        params: dict[str, Any] = {"limit": limit}
+        """Huecos libres, y a la vez la OFERTA de esta conversación.
+
+        `conversationId` no es opcional: el CRM guarda contra esa conversación
+        exactamente lo que devuelve aquí, y después solo acepta reservar uno de
+        esos instantes. Pedir disponibilidad sin decir para quién es responde
+        422 — y esa era la causa de que Nea no pudiera agendar contra un Vocero
+        reciente.
+
+        Con `per_day` el CRM reparte los huecos entre días distintos (si no,
+        los primeros N se los come el día de hoy) y los devuelve con el día
+        desambiguado en `dayLabel`.
+        """
+        params: dict[str, Any] = {
+            "conversationId": conversation_id,
+            "limit": limit,
+        }
         if per_day:
             params["perDay"] = per_day
         if days:
             params["days"] = days
         resp = await self._request("GET", "/api/bot/availability", params=params)
+        if resp.status_code == 404:
+            raise AgendaUnavailable("este CRM no tiene el motor de agenda encendido")
         if resp.status_code != 200:
             raise CrmError(f"availability devolvió {resp.status_code}")
         slots = resp.json().get("slots") or []
         return list(slots)
+
+    async def agenda_available(self) -> bool:
+        """¿Este CRM ofrece agenda?
+
+        Se pregunta SIN `conversationId` a propósito: con la agenda encendida
+        el CRM responde 422 ("falta conversationId") y con ella apagada, 404.
+        Basta para distinguir, no ensucia la oferta de ninguna conversación y
+        no necesita un endpoint nuevo del CRM.
+
+        Ante cualquier otra cosa (red caída, 5xx) se asume que SÍ hay agenda:
+        equivocarse hacia "sí" solo cuesta un intento fallido más adelante,
+        que ya degrada solo; equivocarse hacia "no" apagaría el agendamiento
+        de una instancia que sí lo tiene.
+        """
+        try:
+            resp = await self._request("GET", "/api/bot/availability")
+        except CrmError:
+            return True
+        return resp.status_code != 404
 
     async def create_booking(
         self, conversation_id: str, start_utc: str
@@ -206,6 +275,8 @@ class CrmClient:
         )
         if resp.status_code == 409:
             raise _booking_conflict(resp)
+        if resp.status_code == 404:
+            raise AgendaUnavailable("este CRM no tiene el motor de agenda encendido")
         # El CRM real responde 201 Created (REST); los mocks viejos daban 200.
         if resp.status_code not in (200, 201):
             raise CrmError(f"bookings devolvió {resp.status_code}")
@@ -228,7 +299,12 @@ class CrmClient:
         if resp.status_code == 409:
             raise _booking_conflict(resp)
         if resp.status_code == 404:
-            raise CrmConflict("no_booking", _payload(resp))
+            # Ojo con este 404: puede ser "no hay cita que mover" (agenda
+            # encendida) o "aquí no hay agenda". Los distingue el cuerpo: el
+            # primero trae el sobre de error del CRM; el segundo viene vacío.
+            if _payload(resp):
+                raise CrmConflict("no_booking", _payload(resp))
+            raise AgendaUnavailable("este CRM no tiene el motor de agenda encendido")
         if resp.status_code != 200:
             raise CrmError(f"reschedule devolvió {resp.status_code}")
         data: dict[str, Any] = resp.json()

--- a/app/main.py
+++ b/app/main.py
@@ -75,6 +75,18 @@ def create_app(ctx: AppContext | None = None) -> FastAPI:
         c: AppContext = app.state.ctx
         _wire_coalescer(c)
 
+        if own_resources:
+            # ¿Este CRM agenda? Vocero trae el motor detrás de una bandera de
+            # despliegue y viene apagado por defecto. Se pregunta una vez, aquí,
+            # en vez de descubrirlo lead por lead: así el primero que escriba ya
+            # recibe el comportamiento correcto en vez de una promesa de cita
+            # que no se puede cumplir.
+            c.agenda_enabled = await c.crm.agenda_available()
+            logger.info(
+                "agenda del CRM: %s",
+                "disponible" if c.agenda_enabled else "APAGADA — Nea no ofrecerá citas",
+            )
+
         relay_worker = RelayWorker(c.store, c.settings.crm_webhook_url, c.relay_wake)
         followup_worker = FollowupWorker(c)
         sender_worker = SenderWorker(c)

--- a/app/prompt.py
+++ b/app/prompt.py
@@ -150,6 +150,7 @@ def build_system_prompt(
     conv: Conversation,
     referral_headline: str | None = None,
     offered: list[OfferedSlot] | None = None,
+    agenda: bool = True,
     now: datetime | None = None,
     tz: ZoneInfo | None = None,
 ) -> str:
@@ -157,6 +158,15 @@ def build_system_prompt(
     tz = tz or DEFAULT_TZ
     now = now or datetime.now(timezone.utc)
     lines: list[str] = ["", "CONTEXTO ACTUAL:"]
+    if not agenda:
+        # El CRM de esta instancia no agenda (Vocero trae el motor detrás de
+        # una bandera). Sin esto el agente sigue prometiendo cita y el lead se
+        # topa con una puerta cerrada al final de la conversación.
+        lines.append(
+            "- ESTE NEGOCIO NO AGENDA POR AQUÍ: no ofrezcas horarios ni "
+            "prometas una cita. Resuelve lo que puedas y, cuando el lead "
+            "quiera avanzar, haz handoff para que lo coordine una persona."
+        )
     lines.append(f"- Fecha y hora: {_fmt_local(now, tz)}.")
     # "Mañana" resuelto por el sistema: el lead lo dice todo el tiempo y el
     # modelo no tiene por qué calcularlo (ni equivocarse de día).

--- a/app/state.py
+++ b/app/state.py
@@ -356,6 +356,11 @@ class AppContext:
     profile: Any | None = None  # ProfileProvider; None en tests = perfil mínimo
     coalescer: Any | None = None
     relay_wake: asyncio.Event = field(default_factory=asyncio.Event)
+    # ¿El CRM de esta instancia tiene motor de agenda? Vocero lo trae detrás de
+    # una bandera de despliegue y viene apagado por defecto. Se resuelve al
+    # arrancar (y se corrige solo si en caliente resulta que no está), para no
+    # ofrecerle horarios a un lead contra un CRM que no puede agendarlos.
+    agenda_enabled: bool = True
     # Un candado por identidad: los turnos de UNA conversación se serializan.
     # Sin esto, una ráfaga que llega mientras el turno anterior sigue en vuelo
     # abre un segundo turno con contexto viejo (se reservó una cita antes de

--- a/app/tools.py
+++ b/app/tools.py
@@ -1,9 +1,15 @@
 """Herramientas del LLM: update_ficha, propose_slots, book_session, route_out, handoff.
 
-La validación es server-side: `book_session` SOLO acepta slots previamente
-ofrecidos (tabla offered_slots, comparación por epoch exacto). Un fallo del
-CRM dentro de una tool regresa `{"ok": false, ...}` al LLM — nunca tumba el
-turno.
+Solo se reserva lo que se ofreció, y **quien manda sobre eso es el CRM**:
+Vocero guarda la oferta contra la conversación y rechaza cualquier otro
+instante. La tabla `offered_slots` de Nea es un ESPEJO de esa oferta, no una
+segunda fuente de verdad: sirve para etiquetar con el día en palabras y para
+frenar una alucinación antes de gastar un viaje de red. Si el CRM dice que un
+horario no se ofreció, el espejo está viejo y se resincroniza con lo que él
+mande.
+
+Un fallo del CRM dentro de una tool regresa `{"ok": false, ...}` al LLM —
+nunca tumba el turno.
 """
 from __future__ import annotations
 
@@ -11,7 +17,13 @@ import logging
 from datetime import datetime, timezone
 from typing import Any
 
-from app.crm import CrmConflict, CrmError, SlotTaken
+from app.crm import (
+    AgendaUnavailable,
+    CrmConflict,
+    CrmError,
+    SlotNotOffered,
+    SlotTaken,
+)
 from app.profile import BusinessProfile
 from app.state import AppContext, Conversation, OfferedSlot
 
@@ -162,6 +174,46 @@ TOOL_SCHEMAS: list[dict[str, Any]] = [
 ]
 
 
+# Herramientas que solo tienen sentido si el CRM agenda.
+AGENDA_TOOLS = frozenset({"propose_slots", "book_session", "reschedule_session"})
+
+
+def tool_schemas(agenda_enabled: bool = True) -> list[dict[str, Any]]:
+    """El catálogo que se le ofrece al modelo en ESTE turno.
+
+    Contra un CRM sin agenda no se le enseñan las herramientas de agendar: si
+    se le enseñan, las llama, fallan todas y el lead recibe evasivas en vez de
+    un handoff limpio. Que no exista la herramienta es más claro que pedirle al
+    prompt que se acuerde de no usarla.
+    """
+    if agenda_enabled:
+        return TOOL_SCHEMAS
+    return [
+        t
+        for t in TOOL_SCHEMAS
+        if t.get("function", {}).get("name") not in AGENDA_TOOLS
+    ]
+
+
+def _meeting(result: dict[str, Any]) -> tuple[str | None, bool]:
+    """Enlace de la reunión y si el CRM lo dejó pendiente.
+
+    Vocero devuelve `meetingLink` desde que la entrega de la reunión es un
+    conector (puede ser Zoom, Google Meet o la sala fija del negocio); antes
+    era `zoomJoinUrl`, y ese nombre se sigue aceptando para no romper un CRM
+    viejo. Leer solo el viejo hacía que el enlace llegara SIEMPRE vacío contra
+    un Vocero actual: la cita se creaba bien y el lead se quedaba sin por dónde
+    entrar.
+
+    `linkPending` es lo que evita prometer de más: la cita existe pero el
+    proveedor todavía no entregó el enlace, así que se confirma la cita y se
+    dice que el enlace llega en un momento.
+    """
+    link = result.get("meetingLink") or result.get("zoomJoinUrl")
+    pending = bool(result.get("linkPending"))
+    return (str(link) if link else None), pending
+
+
 def _iso_z(dt: datetime) -> str:
     return dt.astimezone(timezone.utc).isoformat().replace("+00:00", "Z")
 
@@ -269,9 +321,17 @@ class ToolRuntime:
         return {"ok": True}
 
     async def _propose_slots(self) -> dict[str, Any]:
-        raw = await self._ctx.crm.get_availability(
-            limit=MAX_OFFERED, per_day=OFFER_PER_DAY, days=OFFER_DAYS
-        )
+        # La conversación va SIEMPRE: es contra ella que el CRM registra la
+        # oferta, y sin ella no hay nada reservable después.
+        try:
+            raw = await self._ctx.crm.get_availability(
+                self._crm_conv_id,
+                limit=MAX_OFFERED,
+                per_day=OFFER_PER_DAY,
+                days=OFFER_DAYS,
+            )
+        except AgendaUnavailable:
+            return self._sin_agenda()
         slots = _slots_from_payload(self._conv.id, raw)
         if not slots:
             return {
@@ -340,6 +400,55 @@ class ToolRuntime:
         )
         return chosen, None
 
+    def _sin_agenda(self) -> dict[str, Any]:
+        """Este CRM no tiene agenda: dejar de prometer citas, no reintentar."""
+        self._ctx.agenda_enabled = False
+        logger.info("tools: el CRM no expone agenda — agendamiento desactivado")
+        return {
+            "ok": False,
+            "error": "sin_agenda",
+            "detalle": (
+                "este negocio no agenda por aquí; no ofrezcas horarios ni "
+                "prometas cita — resuelve lo que puedas y haz handoff"
+            ),
+        }
+
+    async def _resync_offer(
+        self, exc: SlotNotOffered, accion: str
+    ) -> dict[str, Any]:
+        """El CRM no reconoce ese horario: su lista manda, la nuestra se tira.
+
+        Pasa cuando el espejo local quedó viejo — por ejemplo si el CRM
+        reemplazó la oferta por su cuenta. Antes esto caía en el `except
+        CrmError` genérico y el agente solo decía "no pude"; ahora vuelve a
+        ofrecer lo que el CRM sí tiene registrado.
+        """
+        fresh = _slots_from_payload(self._conv.id, exc.slots)
+        await self._ctx.store.replace_offered_slots(self._conv.id, fresh)
+        logger.info(
+            "tools: %s rechazado por el CRM (no ofrecido) — oferta resincronizada a %d",
+            accion,
+            len(fresh),
+        )
+        if not fresh:
+            return {
+                "ok": False,
+                "error": "slot_no_ofrecido",
+                "detalle": (
+                    "el CRM no tiene horarios ofrecidos en esta conversación; "
+                    "vuelve a llamar propose_slots antes de agendar"
+                ),
+            }
+        return {
+            "ok": False,
+            "error": "slot_no_ofrecido",
+            "detalle": (
+                "ese horario ya no está ofrecido; ofrécele estos, que son los "
+                "que el negocio tiene reservados para esta conversación"
+            ),
+            "slots": _slots_for_llm(fresh),
+        }
+
     async def _book_session(self, args: dict[str, Any]) -> dict[str, Any]:
         chosen, error = await self._resolve_offered(args, "book_session")
         if error is not None or chosen is None:
@@ -358,6 +467,10 @@ class ToolRuntime:
                 "detalle": "ese horario se acaba de ocupar; discúlpate breve y ofrece estas alternativas",
                 "slots": _slots_for_llm(fresh),
             }
+        except SlotNotOffered as exc:
+            return await self._resync_offer(exc, "book_session")
+        except AgendaUnavailable:
+            return self._sin_agenda()
         await self._ctx.store.clear_offered_slots(self._conv.id)
         self.booked = True
         try:
@@ -371,11 +484,14 @@ class ToolRuntime:
             # La etiqueta del slot ofrecido trae el día en palabras; la del
             # CRM es la corta. Se repite ESTA para que el lead lea el día.
             "label": chosen.label or result.get("label"),
-            "zoom_url": result.get("zoomJoinUrl"),
+            "meeting_url": _meeting(result)[0],
+            "enlace_pendiente": _meeting(result)[1],
             "instrucciones": (
                 "confirma el día COMPLETO y la hora tal cual dice label, "
-                "comparte el link de la videollamada si existe y menciona lo "
-                "que el negocio pida para llegar preparado"
+                "comparte meeting_url si viene y menciona lo que el negocio "
+                "pida para llegar preparado. Si enlace_pendiente es true, la "
+                "cita SÍ quedó: di que el enlace le llega por aquí en un "
+                "momento, no prometas uno que no tienes"
             ),
         }
 
@@ -396,6 +512,10 @@ class ToolRuntime:
                 "detalle": "ese horario se acaba de ocupar; discúlpate breve y ofrece estas alternativas",
                 "slots": _slots_for_llm(fresh),
             }
+        except SlotNotOffered as exc:
+            return await self._resync_offer(exc, "reschedule_session")
+        except AgendaUnavailable:
+            return self._sin_agenda()
         except CrmConflict as exc:
             if exc.code == "no_booking":
                 return {
@@ -409,7 +529,8 @@ class ToolRuntime:
         return {
             "ok": True,
             "label": chosen.label or result.get("label"),
-            "zoom_url": result.get("zoomJoinUrl"),
+            "meeting_url": _meeting(result)[0],
+            "enlace_pendiente": _meeting(result)[1],
             "instrucciones": (
                 "confirma que quedó movida, con el día COMPLETO y la hora tal "
                 "cual dice label; el link de la videollamada sigue siendo el "

--- a/app/turn.py
+++ b/app/turn.py
@@ -23,7 +23,7 @@ from app.stall import ALERTA as STALL_ALERT, racha_vacia, sin_rumbo
 from app.profile import resolve_profile
 from app.prompt import build_system_prompt
 from app.state import AppContext, InboundMessage, utcnow
-from app.tools import TOOL_SCHEMAS, ToolRuntime
+from app.tools import ToolRuntime, tool_schemas
 
 logger = logging.getLogger("nea.turn")
 
@@ -199,6 +199,7 @@ async def run_turn(
         conv=conv,
         referral_headline=referral,
         offered=offered,
+        agenda=ctx.agenda_enabled,
         tz=_agent_tz(settings),
     )
     # Se traen más mensajes de los que ve el LLM: el candado de cierre cuenta
@@ -337,7 +338,9 @@ async def _tool_loop(
 ) -> str | None:
     """Rondas de tool-calling hasta obtener texto final (o rendirse)."""
     for _ in range(MAX_TOOL_ROUNDS):
-        reply = await ctx.llm.complete(messages, tools=TOOL_SCHEMAS)
+        reply = await ctx.llm.complete(
+            messages, tools=tool_schemas(ctx.agenda_enabled)
+        )
         if not reply.tool_calls:
             return reply.content  # turno de puro texto
         # content vacío con tool_calls es normal (turno solo-herramientas)

--- a/tests/test_agenda_vocero.py
+++ b/tests/test_agenda_vocero.py
@@ -1,0 +1,255 @@
+"""Compatibilidad con el motor de agenda de Vocero.
+
+Vocero bajó a su núcleo la garantía "solo se reserva lo que se ofreció": la
+oferta se registra CONTRA UNA CONVERSACIÓN y él decide qué es reservable. Estos
+tests fijan que Nea se acopla a eso — y cubren los puntos donde antes rompía en
+silencio contra un Vocero actual.
+"""
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+import httpx
+import pytest
+
+from app.crm import AgendaUnavailable, CrmClient
+from app.state import OfferedSlot
+from app.tools import AGENDA_TOOLS, ToolRuntime, tool_schemas
+from tests.conftest import CRM_CONV_ID, CRM_URL, IDENTITY, make_ctx
+
+SLOT_ISO = "2026-07-20T16:00:00Z"
+SLOT_DT = datetime(2026, 7, 20, 16, 0, tzinfo=timezone.utc)
+
+
+@pytest.fixture
+async def runtime_y_ctx():
+    ctx = make_ctx()
+    conv = await ctx.store.get_or_create_conversation(IDENTITY)
+    await ctx.store.replace_offered_slots(
+        conv.id,
+        [
+            OfferedSlot(
+                conversation_id=conv.id,
+                start_utc=SLOT_DT,
+                end_utc=None,
+                label="lunes 20 de julio, 10:00 am",
+            )
+        ],
+    )
+    yield ToolRuntime(ctx, conv, CRM_CONV_ID), ctx, conv
+    await ctx.crm.aclose()
+
+
+async def test_propose_slots_manda_la_conversacion(runtime_y_ctx, respx_mock):
+    """Sin `conversationId` el CRM responde 422 y Nea se quedaba sin poder
+    ofrecer NADA: es la incompatibilidad que rompía el agendamiento entero."""
+    runtime, _ctx, _conv = runtime_y_ctx
+    route = respx_mock.get(f"{CRM_URL}/api/bot/availability").mock(
+        return_value=httpx.Response(
+            200,
+            json={
+                "slots": [
+                    {
+                        "startUtc": SLOT_ISO,
+                        "endUtc": "2026-07-20T16:30:00Z",
+                        "label": "lun 20 jul, 10:00",
+                        "dayLabel": "lunes 20 de julio",
+                        "time": "10:00",
+                    }
+                ]
+            },
+        )
+    )
+    result = await runtime.execute("propose_slots", {})
+    assert result["ok"] is True
+    assert route.calls[0].request.url.params["conversationId"] == CRM_CONV_ID
+
+
+async def test_slot_no_ofrecido_resincroniza_con_lo_que_dice_el_crm(
+    runtime_y_ctx, respx_mock
+):
+    """El CRM manda: si dice que ese horario no está ofrecido, su lista gana y
+    el agente re-ofrece esa. Antes esto caía en el error genérico y el lead
+    solo escuchaba que no se pudo."""
+    runtime, ctx, conv = runtime_y_ctx
+    del_crm = [
+        {
+            "startUtc": "2026-07-21T17:00:00Z",
+            "label": "mar 21 jul, 11:00",
+            "dayLabel": "martes 21 de julio",
+            "time": "11:00",
+        }
+    ]
+    respx_mock.post(f"{CRM_URL}/api/bot/bookings").mock(
+        return_value=httpx.Response(
+            409,
+            json={
+                "error": {"code": "slot_not_offered", "message": "no se ofrecio"},
+                "slots": del_crm,
+            },
+        )
+    )
+    result = await runtime.execute(
+        "book_session", {"start_utc": SLOT_ISO, "dia_confirmado": "el lunes"}
+    )
+    assert result["ok"] is False
+    assert result["error"] == "slot_no_ofrecido"
+    # Re-ofrece lo del CRM, no se queda mudo.
+    assert result["slots"][0]["label"] == "martes 21 de julio, 11:00"
+    # Y el espejo local quedó igual al del CRM.
+    espejo = await ctx.store.get_offered_slots(conv.id)
+    assert [s.start_utc for s in espejo] == [
+        datetime(2026, 7, 21, 17, 0, tzinfo=timezone.utc)
+    ]
+    assert runtime.booked is False
+
+
+async def test_slot_no_ofrecido_sin_alternativas_manda_a_re_ofrecer(
+    runtime_y_ctx, respx_mock
+):
+    runtime, ctx, conv = runtime_y_ctx
+    respx_mock.post(f"{CRM_URL}/api/bot/bookings").mock(
+        return_value=httpx.Response(
+            409, json={"error": {"code": "slot_not_offered"}, "slots": []}
+        )
+    )
+    result = await runtime.execute("book_session", {"start_utc": SLOT_ISO})
+    assert result["ok"] is False
+    assert "propose_slots" in result["detalle"]
+    assert await ctx.store.get_offered_slots(conv.id) == []
+
+
+async def test_agenda_apagada_deja_de_prometer_citas(runtime_y_ctx, respx_mock):
+    """Vocero trae el motor detrás de una bandera y viene APAGADO por defecto:
+    esos endpoints responden 404. Reintentar contra una puerta que no existe le
+    daría evasivas al lead en vez de un handoff limpio."""
+    runtime, ctx, _conv = runtime_y_ctx
+    respx_mock.get(f"{CRM_URL}/api/bot/availability").mock(
+        return_value=httpx.Response(404)
+    )
+    result = await runtime.execute("propose_slots", {})
+    assert result["ok"] is False
+    assert result["error"] == "sin_agenda"
+    # Y no se vuelve a intentar en los siguientes turnos.
+    assert ctx.agenda_enabled is False
+
+
+async def test_sin_agenda_no_se_le_ensenan_las_herramientas_de_agendar():
+    """Que la herramienta no exista es más claro que pedirle al prompt que se
+    acuerde de no usarla."""
+    con = {t["function"]["name"] for t in tool_schemas(True)}
+    sin = {t["function"]["name"] for t in tool_schemas(False)}
+    assert AGENDA_TOOLS <= con
+    assert not (AGENDA_TOOLS & sin)
+    # Lo demás sigue disponible: sin agenda el agente igual califica y escala.
+    assert {"update_ficha", "handoff"} <= sin
+
+
+async def test_el_enlace_de_la_reunion_llega_aunque_no_sea_zoom(
+    runtime_y_ctx, respx_mock
+):
+    """Vocero devuelve `meetingLink` desde que la reunión la entrega un
+    conector (Zoom, Meet o la sala fija). Leer solo `zoomJoinUrl` dejaba al
+    lead con la cita creada y sin por dónde entrar."""
+    runtime, _ctx, _conv = runtime_y_ctx
+    respx_mock.put(f"{CRM_URL}/api/bot/ficha").mock(
+        return_value=httpx.Response(200, json={"ok": True})
+    )
+    respx_mock.post(f"{CRM_URL}/api/bot/bookings").mock(
+        return_value=httpx.Response(
+            201,
+            json={
+                "bookingId": "bk_1",
+                "meetingLink": "https://meet.google.com/abc",
+                "linkPending": False,
+                "label": "lun 20 jul, 10:00",
+            },
+        )
+    )
+    result = await runtime.execute("book_session", {"start_utc": SLOT_ISO})
+    assert result["ok"] is True
+    assert result["meeting_url"] == "https://meet.google.com/abc"
+    assert result["enlace_pendiente"] is False
+
+
+async def test_enlace_pendiente_no_se_promete(runtime_y_ctx, respx_mock):
+    """El proveedor falló: la cita SÍ existe, el enlace todavía no. Confirmar
+    la cita sin prometer un enlace que no se tiene."""
+    runtime, _ctx, _conv = runtime_y_ctx
+    respx_mock.put(f"{CRM_URL}/api/bot/ficha").mock(
+        return_value=httpx.Response(200, json={"ok": True})
+    )
+    respx_mock.post(f"{CRM_URL}/api/bot/bookings").mock(
+        return_value=httpx.Response(
+            201,
+            json={"bookingId": "bk_1", "meetingLink": None, "linkPending": True},
+        )
+    )
+    result = await runtime.execute("book_session", {"start_utc": SLOT_ISO})
+    assert result["ok"] is True
+    assert result["meeting_url"] is None
+    assert result["enlace_pendiente"] is True
+    assert "no prometas" in result["instrucciones"]
+
+
+async def test_zoom_join_url_sigue_sirviendo(runtime_y_ctx, respx_mock):
+    """Compatibilidad hacia atrás: un CRM viejo manda `zoomJoinUrl`."""
+    runtime, _ctx, _conv = runtime_y_ctx
+    respx_mock.put(f"{CRM_URL}/api/bot/ficha").mock(
+        return_value=httpx.Response(200, json={"ok": True})
+    )
+    respx_mock.post(f"{CRM_URL}/api/bot/bookings").mock(
+        return_value=httpx.Response(
+            201, json={"bookingId": "bk_1", "zoomJoinUrl": "https://zoom.us/j/1"}
+        )
+    )
+    result = await runtime.execute("book_session", {"start_utc": SLOT_ISO})
+    assert result["meeting_url"] == "https://zoom.us/j/1"
+
+
+@pytest.mark.parametrize(
+    "status, esperado",
+    [
+        # Con agenda encendida el CRM pide la conversación: 422 = sí hay agenda.
+        (422, True),
+        (404, False),
+        (200, True),
+    ],
+)
+async def test_sonda_de_capacidad(respx_mock, status, esperado):
+    """Se pregunta SIN conversationId a propósito: distingue las dos
+    configuraciones sin ensuciar la oferta de nadie ni pedirle al CRM un
+    endpoint nuevo."""
+    respx_mock.get(f"{CRM_URL}/api/bot/availability").mock(
+        return_value=httpx.Response(status, json={})
+    )
+    crm = CrmClient(CRM_URL, "k")
+    try:
+        assert await crm.agenda_available() is esperado
+    finally:
+        await crm.aclose()
+
+
+async def test_sonda_ante_crm_caido_asume_que_si_hay_agenda(respx_mock):
+    """Equivocarse hacia el sí cuesta un intento fallido que ya degrada solo;
+    hacia el no apagaría el agendamiento de una instancia que sí lo tiene."""
+    respx_mock.get(f"{CRM_URL}/api/bot/availability").mock(
+        side_effect=httpx.ConnectError("sin red")
+    )
+    crm = CrmClient(CRM_URL, "k")
+    try:
+        assert await crm.agenda_available() is True
+    finally:
+        await crm.aclose()
+
+
+async def test_availability_404_es_agenda_apagada_no_error_generico(respx_mock):
+    respx_mock.get(f"{CRM_URL}/api/bot/availability").mock(
+        return_value=httpx.Response(404)
+    )
+    crm = CrmClient(CRM_URL, "k")
+    try:
+        with pytest.raises(AgendaUnavailable):
+            await crm.get_availability(CRM_CONV_ID)
+    finally:
+        await crm.aclose()


### PR DESCRIPTION
## El problema

Vocero bajó a su núcleo la garantía *"solo se reserva lo que se ofreció"*:
registra la oferta **contra una conversación** y solo acepta reservar uno de
esos instantes. Nea seguía guardando esa memoria por su cuenta y pidiendo
disponibilidad sin decir para quién, así que contra un Vocero actual el
agendamiento estaba **muerto**.

Medido replicando las llamadas de `app/crm.py` contra un Vocero vivo:

| Llamada de Nea | Vocero `AGENDA=on` | Vocero por defecto |
|---|---|---|
| `profile` · `context` · `typing` · `ficha` · `messages` · `handoff` · `reset` | 200 ✅ | 200 ✅ |
| `GET /api/bot/availability?limit&perDay&days` | **422** ❌ | **404** ❌ |
| `POST /api/bot/bookings` | **409 `slot_not_offered`** ❌ | **404** ❌ |
| `PATCH /api/bot/bookings` | **409 `slot_not_offered`** ❌ | **404** ❌ |

Degradaba con elegancia —nunca reventaba el turno— pero el lead no podía
agendar, que es la razón de ser de Nea.

## Qué cambia (todo del lado de Nea)

**1. `conversationId` en `get_availability`.** Es contra él que el CRM registra
la oferta. Sin él, 422 y nada reservable después.

**2. La autoridad sobre lo ofrecido pasa al CRM.** `offered_slots` queda como
**espejo**: etiqueta con el día en palabras y frena alucinaciones antes de
gastar un viaje de red. Ante un `slot_not_offered`, la lista del CRM gana, el
espejo se resincroniza y el agente **re-ofrece** — en vez de caer en el
`except CrmError` genérico y decirle al lead "no pude".

**3. La agenda puede no existir.** En Vocero va detrás de la bandera `AGENDA`,
**apagada por defecto**. Se sondea al arrancar con `agenda_available()`, que
distingue 404 (no hay agenda) de 422 (sí hay, falta la conversación) sin pedirle
al CRM un endpoint nuevo. Sin agenda no se le enseñan al modelo las
herramientas de agendar y el prompt se lo dice: escala en vez de prometer una
cita imposible. Que la herramienta no exista es más fiable que pedirle al
prompt que se acuerde de no usarla.

**4. El enlace de la reunión.** Vocero devuelve `meetingLink` desde que la
entrega es un conector (Zoom, Meet o la sala fija); Nea leía solo
`zoomJoinUrl`, así que el enlace llegaba **siempre vacío**: la cita se creaba
bien y el lead se quedaba sin por dónde entrar. Ahora lee el nuevo con el viejo
como respaldo, y propaga `linkPending` — la cita quedó, el enlace llega en un
momento; no se promete lo que no se tiene.

> Este cuarto punto no lo delataban los códigos de estado: todo respondía 201.
> Salió de comparar campo por campo el cuerpo real de la respuesta.

## Verificación

**122 pytest verdes** (13 nuevos), y sobre todo **en vivo contra un Vocero real
corriendo, sin mocks del CRM**, en las dos configuraciones de la bandera:

```
=== Nea contra Vocero vivo (agenda: on) ===
  OK   la sonda detecta si el CRM agenda
  OK   se le ofrecen las herramientas de agendar
  OK   propose_slots trae horarios reales del CRM
  OK   y son varios días, no solo hoy
  OK   un horario que nadie ofreció se rechaza
  OK   book_session agenda de verdad
  OK   y devuelve el enlace de la reunión
  OK   sin dejarlo pendiente
  OK   la cita quedó registrada en Vocero
  OK   reschedule_session mueve la cita

=== Nea contra Vocero vivo (agenda: off) ===
  OK   la sonda detecta si el CRM agenda
  OK   NO se le ofrecen herramientas de agendar
  OK   sin agenda, propose_slots lo dice claro
  OK   y deja de intentarlo en los siguientes turnos
```

## Notas

- **Sin variables de entorno nuevas**: la capacidad se descubre, no se
  configura. Un `.env` existente sigue sirviendo tal cual.
- **Compatible hacia atrás** con un CRM viejo: `zoomJoinUrl` se sigue leyendo, y
  si el CRM no exige `conversationId`, mandarlo no estorba.
- **Queda fuera**: Nea sigue siendo WhatsApp puro. Los DMs de Instagram entran
  por el webhook propio de Vocero y Nea no los ve — eso es una feature, no un
  arreglo de compatibilidad.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
