### PR TITLE
Modo cloud: Nea detras de un Vocero multitenant

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -99,3 +99,26 @@ EVOLUTION_INSTANCE=REEMPLAZA_instancia
 EVOLUTION_APIKEY=REEMPLAZA_apikey
 # Número al que escribe el tester (único destino permitido)
 LIVE_TARGET_NUMBER=REEMPLAZA_52XXXXXXXXXX
+
+# --- Modo cloud: Nea detrás de un Vocero multitenant (opcional) --------------
+#
+# Vacío = comportamiento de SIEMPRE. Meta manda el webhook a Nea, Nea lo relaya
+# al CRM y habla con /api/bot/*. Si tienes Nea funcionando, NO toques nada de
+# aquí abajo: sin VOCERO_MODE nada de esto se activa.
+#
+# "cloud" = Nea vive detrás de un Vocero multitenant. Cambian tres cosas:
+#   - El CRM recibe el mensaje y se lo DESPACHA a Nea firmado
+#     (POST /vocero/dispatch), en vez de que Meta le pegue a Nea.
+#   - Nea contesta por /api/brains/* con el secreto de la organización.
+#   - No hay relay: el CRM ya tiene el mensaje, reenviárselo lo duplicaría.
+# En este modo NO hacen falta META_APP_SECRET, VERIFY_TOKEN ni CRM_WEBHOOK_URL:
+# Nea deja de hablar con Meta directamente.
+VOCERO_MODE=
+
+# El secreto que genera el CRM en Ajustes → Cerebro. Firma lo que llega Y
+# autentica lo que sale: el mismo en las dos direcciones.
+CRM_BRAIN_SECRET=
+
+# El slug de la organización ({slug}.tudominio.com). El CRM verifica que el
+# secreto y el slug correspondan, así que acertar uno sin el otro no sirve.
+CRM_ORGANIZATION=

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,33 @@
+name: tests
+
+# Corre en cada PR y en cada push a main.
+#
+# Por qué existe: hasta ahora las pruebas dependían de que alguien se acordara
+# de correrlas. Y este repositorio no es de una persona — los miembros de la
+# comunidad despliegan de aquí, así que un error que llegue a `main` les llega
+# a ellos en su siguiente redespliegue.
+#
+# Python 3.11 porque es el del Dockerfile: probar en una versión distinta de la
+# que corre en producción es probar otra cosa.
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+jobs:
+  pytest:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+          cache: pip
+
+      - name: Instalar dependencias
+        run: pip install -r requirements-dev.txt
+
+      - name: Pruebas
+        run: python -m pytest -q

--- a/README.md
+++ b/README.md
@@ -60,6 +60,27 @@ Herramientas del LLM: `update_ficha` (calificación), `propose_slots` /
 `book_session` (agenda), `route_out` (no califica; comparte los recursos
 alternativos del perfil), `handoff` (pausa la IA en el CRM).
 
+### Modo cloud (opcional): detrás de un Vocero multitenant
+
+Con `VOCERO_MODE=cloud` el camino se invierte — el CRM recibe el mensaje y se
+lo despacha a Nea:
+
+```
+Meta ──► Vocero CRM (multitenant)
+             │  el mensaje YA está en la bandeja
+             ▼  POST /vocero/dispatch (firmado con el secreto de la org)
+           Nea
+             └─ contesta por POST {CRM}/api/brains/* con ese mismo secreto
+```
+
+Una sola Nea sirve a muchos negocios, y **cada uno trae su personalidad desde
+SU CRM**: nombre, tono, instrucciones y conocimiento salen del contexto de la
+conversación, no del código ni del brief local.
+
+Sin la bandera no cambia nada: el webhook de Meta, el relay y `/api/bot/*`
+siguen siendo los de siempre. Las variables del modo cloud están en
+`.env.example`.
+
 ## Quickstart
 
 Requisitos: Python 3.11+, Postgres propio (no el del CRM), una instancia de

--- a/app/config.py
+++ b/app/config.py
@@ -60,6 +60,27 @@ class Settings(BaseSettings):
     # "Escribiendo…" casi inmediato al recibir un mensaje (antes del coalesce).
     typing_delay_seconds: float = 0.5
 
+    # ── Modo cloud (Vocero multitenant) ───────────────────────────────
+    #
+    # Vacío = comportamiento de SIEMPRE: Meta manda el webhook a Nea, Nea lo
+    # relaya al CRM y habla con `/api/bot/*`. Ninguna instalación existente
+    # cambia por añadir esto, y ninguna variable nueva es obligatoria.
+    #
+    # `cloud` = Nea vive detrás de un Vocero multitenant: el CRM ya recibió el
+    # mensaje y se lo DESPACHA a Nea firmado, y Nea contesta por
+    # `/api/brains/*`. Una sola Nea sirve a muchos negocios, y cada uno trae su
+    # personalidad desde SU CRM.
+    vocero_mode: str = ""
+
+    # Secreto del cerebro, el que genera el CRM en Ajustes → Cerebro. Firma lo
+    # que llega y autentica lo que sale: el mismo secreto en las dos
+    # direcciones, como en el contrato.
+    crm_brain_secret: str = ""
+
+    # Slug de la organización. Solo se usa para acompañar al secreto; el CRM
+    # verifica que coincidan, así que no sirve de nada acertar uno sin el otro.
+    crm_organization: str = ""
+
     # Infra
     database_url: str = ""
     port: int = 8000
@@ -67,6 +88,16 @@ class Settings(BaseSettings):
     # Desarrollo: loguear el JSON crudo de mensajes no-texto entrantes para
     # capturar los formatos reales de Meta (spec 002). Apagar al terminar.
     capture_payloads: bool = False
+
+    @property
+    def cloud_mode(self) -> bool:
+        """¿Nea corre detrás de un Vocero multitenant?
+
+        Se compara en minúsculas y sin espacios para que un `Cloud ` copiado
+        de una consola no deje a nadie preguntándose por qué no arrancó en el
+        modo que pidió.
+        """
+        return self.vocero_mode.strip().lower() == "cloud"
 
     @staticmethod
     def _identities(csv: str) -> frozenset[str]:

--- a/app/crm_brains.py
+++ b/app/crm_brains.py
@@ -1,0 +1,228 @@
+"""Cliente del CRM para el modo cloud: la superficie `/api/brains/*`.
+
+Vocero tiene dos superficies para un agente externo, y no son la misma:
+
+- `/api/bot/*`   — el Vocero de un solo negocio. Autentica con `X-API-Key` y
+                   la organización es "la única que hay".
+- `/api/brains/*` — el Vocero multitenant. Autentica con el secreto de UNA
+                   organización, y el CRM verifica que el secreto y el slug
+                   correspondan: un cerebro no puede actuar sobre otra
+                   organización aunque adivine su nombre.
+
+Esta clase habla la segunda. Hereda de `CrmClient` a propósito: los métodos que
+solo cambian de ruta se reescriben en `_request` con una tabla, y aquí abajo
+quedan únicamente aquellos cuya RESPUESTA tiene otra forma. Así, cuando el
+contrato crezca, se ve de un vistazo qué difiere de verdad.
+
+Nada de esto se activa sin `VOCERO_MODE=cloud`. Una instalación existente no
+cambia por que este archivo exista.
+"""
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+import httpx
+
+from app.crm import (
+    AgendaUnavailable,
+    CrmClient,
+    CrmError,
+    _booking_conflict,
+)
+
+logger = logging.getLogger("nea.crm.brains")
+
+# Las rutas que solo cambian de sitio. Las que además cambian de forma tienen
+# su propio método más abajo.
+RUTAS = {
+    "/api/bot/context": "/api/brains/context",
+    "/api/bot/messages": "/api/brains/messages",
+    "/api/bot/ficha": "/api/brains/ficha",
+    "/api/bot/handoff": "/api/brains/handoff",
+    "/api/bot/typing": "/api/brains/typing",
+    "/api/bot/availability": "/api/brains/agenda/slots",
+    "/api/bot/bookings": "/api/brains/agenda/book",
+}
+
+
+class BrainsCrmClient(CrmClient):
+    def __init__(
+        self,
+        base_url: str,
+        secret: str,
+        organization: str,
+        timeout: float = 15.0,
+        client: httpx.AsyncClient | None = None,
+    ) -> None:
+        self._http = client or httpx.AsyncClient(
+            base_url=base_url.rstrip("/"),
+            headers={
+                "Authorization": f"Bearer {secret}",
+                "X-Vocero-Organization": organization,
+            },
+            timeout=timeout,
+        )
+        # De qué conversación es cada identidad. Lo llena el despacho: el CRM
+        # ya sabe de quién es el mensaje, así que Nea no tiene que averiguarlo.
+        self._conversaciones: dict[str, str] = {}
+        # El perfil viaja DENTRO del contexto en esta superficie. Se guarda al
+        # pedirlo para que `get_profile()` no gaste una llamada de más por
+        # turno — y para que el perfil sea el de la conversación que se está
+        # atendiendo, no el de una petición suelta.
+        self._perfil: dict[str, Any] | None = None
+
+    def registrar(self, identity: str, conversation_id: str) -> None:
+        """Asocia una identidad con su conversación, desde el despacho."""
+        self._conversaciones[identity] = conversation_id
+
+    def _request(self, method: str, url: str, **kwargs: Any):  # type: ignore[override]
+        return super()._request(method, RUTAS.get(url, url), **kwargs)
+
+    async def get_context(self, wa_identity: str) -> dict[str, Any] | None:
+        """El contexto, pedido por conversación y no por identidad.
+
+        `/api/brains/context` no acepta `waIdentity`: el ámbito de un cerebro
+        es la organización de su secreto, y dejar buscar por teléfono sería
+        darle una forma de preguntar por gente que no le corresponde.
+
+        Sin conversación conocida devuelve None, que es lo mismo que dice el
+        camino de siempre cuando el CRM aún no conoce la identidad: el turno se
+        queda callado en vez de inventar.
+        """
+        conversation_id = self._conversaciones.get(wa_identity)
+        if not conversation_id:
+            logger.warning(
+                "identidad %s sin conversación conocida — ¿llegó por el despacho?",
+                wa_identity,
+            )
+            return None
+
+        resp = await self._request(
+            "GET", "/api/bot/context", params={"conversationId": conversation_id}
+        )
+        if resp.status_code == 404:
+            return None
+        if resp.status_code != 200:
+            raise CrmError(f"context devolvió {resp.status_code}")
+        data: dict[str, Any] = resp.json()
+        self._perfil = _perfil_desde_contexto(data)
+        return data
+
+    async def get_profile(self) -> dict[str, Any] | None:
+        """El perfil que vino con el último contexto.
+
+        En esta superficie el perfil no tiene endpoint propio: viaja con el
+        contexto de la conversación. Devolver el guardado —en vez de pedirlo
+        otra vez— evita una llamada por turno y garantiza que el perfil es el
+        de la organización que se está atendiendo.
+        """
+        return self._perfil
+
+    async def agenda_available(self) -> bool:
+        """¿Este CRM agenda? 404 = la bandera está apagada allá."""
+        try:
+            resp = await self._request(
+                "GET", "/api/bot/availability", params={"conversationId": "cv_sonda"}
+            )
+        except CrmError:
+            # Sin respuesta no se puede concluir que NO haya agenda. Se asume
+            # que sí y el primer intento real lo dirá: prometer menos de lo que
+            # hay es tan malo como prometer de más.
+            return True
+        return resp.status_code != 404
+
+    async def get_availability(
+        self,
+        conversation_id: str,
+        limit: int = 6,
+        per_day: int | None = None,
+        days: int | None = None,
+    ) -> list[dict[str, Any]]:
+        """Huecos libres, y a la vez la OFERTA de esta conversación.
+
+        `limit`, `perDay` y `days` no viajan: en esta superficie el reparto lo
+        decide el CRM, que es quien conoce el horario del negocio. Se aceptan
+        en la firma para no romper a quien ya llama con ellos.
+        """
+        resp = await self._request(
+            "GET",
+            "/api/bot/availability",
+            params={"conversationId": conversation_id},
+        )
+        if resp.status_code == 404:
+            raise AgendaUnavailable("este CRM no tiene el motor de agenda encendido")
+        if resp.status_code != 200:
+            raise CrmError(f"availability devolvió {resp.status_code}")
+        slots = resp.json().get("slots") or []
+        return list(slots)[:limit]
+
+    async def create_booking(
+        self, conversation_id: str, start_utc: str
+    ) -> dict[str, Any]:
+        return await self._agendar("POST", conversation_id, start_utc, "bookings")
+
+    async def reschedule_booking(
+        self, conversation_id: str, start_utc: str
+    ) -> dict[str, Any]:
+        return await self._agendar("PATCH", conversation_id, start_utc, "reschedule")
+
+    async def _agendar(
+        self, method: str, conversation_id: str, start_utc: str, que: str
+    ) -> dict[str, Any]:
+        resp = await self._request(
+            method,
+            "/api/bot/bookings",
+            json={"conversationId": conversation_id, "startUtc": start_utc},
+        )
+        if resp.status_code == 409:
+            raise _booking_conflict(resp)
+        if resp.status_code == 404:
+            raise AgendaUnavailable("este CRM no tiene el motor de agenda encendido")
+        if resp.status_code not in (200, 201):
+            raise CrmError(f"{que} devolvió {resp.status_code}")
+        return _aplanar_reserva(resp.json())
+
+    async def post_reset(self, conversation_id: str) -> None:
+        """El reinicio de pruebas no existe en esta superficie.
+
+        No es un fallo: es una herramienta del entorno de un solo negocio. Se
+        registra y se sigue, porque hacerlo estallar convertiría un comando de
+        pruebas en una caída del turno.
+        """
+        logger.info("reset no disponible en modo cloud — ignorado")
+
+
+def _perfil_desde_contexto(data: dict[str, Any]) -> dict[str, Any]:
+    """Traduce `agent` + `knowledge` a lo que espera `profile_from_payload`.
+
+    El conocimiento llega como pares pregunta/respuesta y se aplana a texto:
+    es lo que ya sabe consumir el prompt, y hacerlo aquí evita tocarlo.
+    """
+    agent = data.get("agent") or {}
+    knowledge = data.get("knowledge") or []
+    bloques = [
+        f"P: {k.get('question')}\nR: {k.get('answer')}"
+        for k in knowledge
+        if isinstance(k, dict) and k.get("question") and k.get("answer")
+    ]
+    return {
+        "profile": agent,
+        "kb": "\n\n".join(bloques) if bloques else None,
+        # Esta superficie todavía no expone los recursos del negocio (enlaces
+        # que el agente puede compartir). Lista vacía en vez de omitirla: el
+        # consumidor ya la trata como opcional.
+        "resources": [],
+    }
+
+
+def _aplanar_reserva(payload: dict[str, Any]) -> dict[str, Any]:
+    """`{ok, booking:{…}}` → los campos al ras, como los devuelve `/api/bot/*`.
+
+    Se aplana aquí y no en quien consume para que el resto de Nea no tenga que
+    saber por qué superficie entró la respuesta.
+    """
+    booking = payload.get("booking")
+    if not isinstance(booking, dict):
+        return payload
+    return {**payload, **booking}

--- a/app/dispatch.py
+++ b/app/dispatch.py
@@ -1,0 +1,152 @@
+"""Entrada del modo cloud: el CRM le DESPACHA la conversación a Nea.
+
+Es la inversión del camino de siempre. Con un Vocero de un solo negocio, Meta
+manda el webhook a Nea y Nea lo relaya al CRM. Con un Vocero multitenant el
+mensaje ya está guardado en la bandeja antes de que Nea lo vea, y el CRM se lo
+entrega firmado.
+
+Eso cambia tres cosas, y las tres para bien:
+
+- **No hay relay.** El CRM ya tiene el mensaje; reenviárselo sería duplicarlo.
+- **No hay coalesce aquí.** El CRM ya esperó a que el cliente terminara de
+  escribir y entrega la ráfaga junta. Volver a esperar en Nea le sumaría
+  segundos de silencio a un cliente que ya esperó los del CRM.
+- **No se parsea a Meta.** Llega un evento normalizado, igual para WhatsApp que
+  para Instagram que para lo que venga después.
+
+Esta ruta solo existe con `VOCERO_MODE=cloud`. Sin esa bandera, Nea no la monta
+y su webhook de Meta sigue siendo el de siempre.
+"""
+from __future__ import annotations
+
+import asyncio
+import hashlib
+import hmac
+import json
+import logging
+from typing import Any
+
+from fastapi import APIRouter, Request
+from fastapi.responses import JSONResponse
+
+from app.state import AppContext, InboundMessage
+from app.turn import handle_flush
+
+logger = logging.getLogger("nea.dispatch")
+
+router = APIRouter()
+
+_bg_tasks: set[asyncio.Task[Any]] = set()
+
+
+def firma_valida(body: bytes, header: str | None, secret: str) -> bool:
+    """HMAC-SHA256 sobre el cuerpo CRUDO, con prefijo `sha256=`.
+
+    Sobre el cuerpo crudo y no sobre el JSON re-serializado: un espacio de
+    diferencia y la firma no coincide nunca. Es el error clásico de esta clase
+    de integración, y por eso se valida antes de parsear nada.
+
+    Sin secreto configurado se RECHAZA. Es lo contrario de lo que hace el
+    webhook de Meta —donde un secreto vacío significa "dev, no verifiques"—, y
+    la diferencia es deliberada: aquí el secreto es la única prueba de que
+    quien despacha es el CRM y no cualquiera que conozca la URL.
+    """
+    if not secret or not header:
+        return False
+    esperado = hmac.new(secret.encode(), body, hashlib.sha256).hexdigest()
+    recibido = header[7:] if header.startswith("sha256=") else header
+    return hmac.compare_digest(recibido, esperado)
+
+
+def mensajes_del_despacho(payload: dict[str, Any]) -> list[InboundMessage]:
+    """Traduce el evento del CRM a lo que ya sabe consumir el turno.
+
+    Tolerante a propósito: un mensaje de un tipo que Nea todavía no maneja no
+    puede tumbar la ráfaga entera — se ignora y los demás siguen.
+    """
+    contacto = payload.get("contact") or {}
+    identity = str(contacto.get("identity") or "")
+    if not identity:
+        return []
+
+    out: list[InboundMessage] = []
+    for m in payload.get("messages") or []:
+        if not isinstance(m, dict):
+            continue
+        out.append(
+            InboundMessage(
+                wa_message_id=str(m.get("id")) if m.get("id") else None,
+                identity=identity,
+                type=str(m.get("type") or "text"),
+                text=m.get("text"),
+                profile_name=contacto.get("displayName"),
+                media_id=m.get("mediaId"),
+                media_mime=m.get("mimeType"),
+                media_caption=m.get("caption"),
+            )
+        )
+    return out
+
+
+@router.post("/vocero/dispatch")
+async def recibir(request: Request) -> Any:
+    """Acusa recibo YA y procesa fuera de la ruta.
+
+    El CRM reintenta con backoff si tardamos, así que responder rápido no es
+    una optimización: es lo que evita procesar el mismo mensaje tres veces.
+    """
+    ctx: AppContext = request.app.state.ctx
+    body = await request.body()
+
+    if not firma_valida(
+        body,
+        request.headers.get("x-vocero-signature"),
+        ctx.settings.crm_brain_secret,
+    ):
+        logger.warning("despacho con firma inválida o ausente — 401")
+        return JSONResponse({"error": "firma inválida"}, status_code=401)
+
+    try:
+        payload = json.loads(body)
+    except (ValueError, UnicodeDecodeError):
+        # 4xx a propósito: el CRM NO reintenta un cuerpo que no entendemos, y
+        # así la conversación cae a un humano en vez de dar tres vueltas.
+        logger.warning("despacho ilegible — 400")
+        return JSONResponse({"error": "cuerpo ilegible"}, status_code=400)
+    if not isinstance(payload, dict):
+        return JSONResponse({"error": "cuerpo inesperado"}, status_code=400)
+
+    task = asyncio.create_task(_procesar(ctx, payload))
+    _bg_tasks.add(task)
+    task.add_done_callback(_bg_tasks.discard)
+    return {"status": "ok"}
+
+
+async def _procesar(ctx: AppContext, payload: dict[str, Any]) -> None:
+    dispatch_id = str(payload.get("dispatchId") or "")
+    conversation = payload.get("conversation") or {}
+    conversation_id = str(conversation.get("id") or "")
+
+    mensajes = mensajes_del_despacho(payload)
+    if not mensajes or not conversation_id:
+        logger.warning("despacho %s sin mensajes o sin conversación", dispatch_id)
+        return
+    identity = mensajes[0].identity
+
+    # Dedup por despacho, no por mensaje: el CRM reintenta el DESPACHO entero
+    # cuando no le acusamos recibo, y contar sus mensajes uno por uno dejaría
+    # pasar el segundo intento con la mitad de la ráfaga ya marcada.
+    if dispatch_id:
+        fresco = await ctx.store.mark_processed(f"dsp:{dispatch_id}")
+        if not fresco:
+            logger.info("dedup: despacho %s ya procesado — ignorado", dispatch_id)
+            return
+
+    # El CRM ya sabe de quién es esta conversación; el cliente lo recuerda para
+    # no tener que preguntarlo por teléfono, que en esta superficie ni se puede.
+    registrar = getattr(ctx.crm, "registrar", None)
+    if callable(registrar):
+        registrar(identity, conversation_id)
+
+    # Directo al turno, sin coalescer: el CRM ya agrupó la ráfaga.
+    await handle_flush(ctx, identity, mensajes)

--- a/app/main.py
+++ b/app/main.py
@@ -20,6 +20,8 @@ from fastapi.responses import JSONResponse
 from app.coalesce import Coalescer
 from app.config import Settings
 from app.crm import CrmClient
+from app.crm_brains import BrainsCrmClient
+from app.dispatch import router as dispatch_router
 from app.db import PgStore
 from app.followup import FollowupWorker
 from app.llm import OpenAiLlm
@@ -56,7 +58,17 @@ def create_app(ctx: AppContext | None = None) -> FastAPI:
             await store.connect()
             await store.migrate(MIGRATIONS_DIR)
             logger.info("migraciones aplicadas — DB lista")
-            crm = CrmClient(settings.crm_base_url, settings.crm_bot_api_key)
+            # Modo cloud: otra superficie del CRM y otra autenticación. Sin la
+            # bandera, exactamente el cliente de siempre.
+            crm = (
+                BrainsCrmClient(
+                    settings.crm_base_url,
+                    settings.crm_brain_secret,
+                    settings.crm_organization,
+                )
+                if settings.cloud_mode
+                else CrmClient(settings.crm_base_url, settings.crm_bot_api_key)
+            )
             app.state.ctx = AppContext(
                 settings=settings,
                 store=store,
@@ -91,11 +103,21 @@ def create_app(ctx: AppContext | None = None) -> FastAPI:
         followup_worker = FollowupWorker(c)
         sender_worker = SenderWorker(c)
         workers = [
-            asyncio.create_task(relay_worker.run(), name="relay-worker"),
             asyncio.create_task(followup_worker.run(), name="followup-worker"),
             asyncio.create_task(sender_worker.run(), name="sender-worker"),
         ]
-        logger.info("Nea arriba: relay + followup + sender corriendo")
+        # El relay reenvía al CRM el payload crudo de Meta. En cloud el CRM YA
+        # tiene el mensaje —él lo recibió y él nos lo despachó—, así que
+        # reenviárselo sería duplicarlo en la bandeja del cliente.
+        if not c.settings.cloud_mode:
+            workers.insert(
+                0, asyncio.create_task(relay_worker.run(), name="relay-worker")
+            )
+        logger.info(
+            "Nea arriba (%s): %sfollowup + sender corriendo",
+            "cloud" if c.settings.cloud_mode else "meta",
+            "" if c.settings.cloud_mode else "relay + ",
+        )
         try:
             yield
         finally:
@@ -114,6 +136,10 @@ def create_app(ctx: AppContext | None = None) -> FastAPI:
     if ctx is not None:
         _wire_coalescer(ctx)
     app.include_router(webhook_router)
+    # La entrada del despacho solo existe en cloud. Montarla siempre dejaría
+    # una ruta pública de más en cada instalación que no la usa.
+    if (ctx.settings if ctx is not None else Settings()).cloud_mode:
+        app.include_router(dispatch_router)
 
     @app.get("/health")
     async def health(request: Request):  # type: ignore[no-untyped-def]

--- a/tests/test_cloud_mode.py
+++ b/tests/test_cloud_mode.py
@@ -1,0 +1,327 @@
+"""Modo cloud: Nea detrás de un Vocero multitenant.
+
+Lo que fijan estos tests es la frontera entre los dos modos. Sin
+`VOCERO_MODE=cloud` nada de esto se activa y Nea se comporta como siempre —esa
+es la garantía que protege a las instalaciones que ya existen—, y con la
+bandera cambia la superficie del CRM, la autenticación y por dónde entran los
+mensajes.
+"""
+from __future__ import annotations
+
+import hashlib
+import hmac
+import json
+
+import httpx
+import pytest
+import respx
+
+from app.config import Settings
+from app.crm_brains import (
+    BrainsCrmClient,
+    _aplanar_reserva,
+    _perfil_desde_contexto,
+)
+from app.dispatch import firma_valida, mensajes_del_despacho
+
+CRM_URL = "http://crm.test"
+SECRETO = "secreto-del-cerebro-de-prueba"
+CONV = "cv_nube1"
+IDENTITY = "525550001111"
+
+
+def firmar(cuerpo: bytes, secreto: str = SECRETO) -> str:
+    return "sha256=" + hmac.new(secreto.encode(), cuerpo, hashlib.sha256).hexdigest()
+
+
+# ── La bandera ────────────────────────────────────────────────────────────
+
+
+class TestBandera:
+    def test_sin_bandera_no_es_cloud(self) -> None:
+        # La garantía que protege a toda instalación existente.
+        assert Settings(vocero_mode="").cloud_mode is False
+
+    def test_con_la_bandera_si(self) -> None:
+        assert Settings(vocero_mode="cloud").cloud_mode is True
+
+    def test_tolera_mayusculas_y_espacios(self) -> None:
+        # Copiado de una consola. Que no arranque en el modo que se pidió por
+        # un espacio invisible es de las cosas más caras de diagnosticar.
+        assert Settings(vocero_mode=" Cloud ").cloud_mode is True
+
+    def test_cualquier_otro_valor_es_el_modo_de_siempre(self) -> None:
+        assert Settings(vocero_mode="meta").cloud_mode is False
+
+
+# ── La firma del despacho ─────────────────────────────────────────────────
+
+
+class TestFirma:
+    def test_valida_el_cuerpo_crudo(self) -> None:
+        cuerpo = b'{"dispatchId":"dsp_1"}'
+        assert firma_valida(cuerpo, firmar(cuerpo), SECRETO) is True
+
+    def test_no_valida_un_cuerpo_reserializado(self) -> None:
+        # El error clásico: firmar el JSON parseado y vuelto a serializar. Un
+        # espacio de diferencia y no coincide nunca.
+        original = b'{"dispatchId":"dsp_1", "x":1}'
+        reserializado = json.dumps(json.loads(original)).encode()
+        assert original != reserializado
+        assert firma_valida(reserializado, firmar(original), SECRETO) is False
+
+    def test_rechaza_la_firma_de_otro_secreto(self) -> None:
+        cuerpo = b"{}"
+        assert firma_valida(cuerpo, firmar(cuerpo, "otro"), SECRETO) is False
+
+    def test_sin_secreto_configurado_RECHAZA(self) -> None:
+        # Al revés que el webhook de Meta, donde un secreto vacío significa
+        # "dev, no verifiques". Aquí el secreto es la única prueba de que quien
+        # despacha es el CRM y no cualquiera que conozca la URL.
+        cuerpo = b"{}"
+        assert firma_valida(cuerpo, firmar(cuerpo), "") is False
+
+    def test_sin_cabecera_rechaza(self) -> None:
+        assert firma_valida(b"{}", None, SECRETO) is False
+
+    def test_acepta_la_firma_sin_el_prefijo(self) -> None:
+        cuerpo = b"{}"
+        crudo = hmac.new(SECRETO.encode(), cuerpo, hashlib.sha256).hexdigest()
+        assert firma_valida(cuerpo, crudo, SECRETO) is True
+
+
+# ── El evento del CRM ─────────────────────────────────────────────────────
+
+
+class TestDespacho:
+    def test_traduce_la_rafaga_entera(self) -> None:
+        # El CRM ya esperó a que el cliente terminara de escribir y entrega los
+        # mensajes juntos: son UNA pregunta, no tres.
+        msgs = mensajes_del_despacho(
+            {
+                "contact": {"identity": IDENTITY, "displayName": "Ana"},
+                "messages": [
+                    {"id": "msg_1", "type": "text", "text": "hola"},
+                    {"id": "msg_2", "type": "text", "text": "¿tienen el azul?"},
+                ],
+            }
+        )
+        assert [m.text for m in msgs] == ["hola", "¿tienen el azul?"]
+        assert {m.identity for m in msgs} == {IDENTITY}
+        assert msgs[0].profile_name == "Ana"
+
+    def test_pasa_los_adjuntos(self) -> None:
+        msgs = mensajes_del_despacho(
+            {
+                "contact": {"identity": IDENTITY},
+                "messages": [
+                    {
+                        "id": "msg_1",
+                        "type": "image",
+                        "mediaId": "med_1",
+                        "mimeType": "image/jpeg",
+                        "caption": "así",
+                    }
+                ],
+            }
+        )
+        assert msgs[0].media_id == "med_1"
+        assert msgs[0].media_mime == "image/jpeg"
+
+    def test_sin_identidad_no_devuelve_nada(self) -> None:
+        # Sin identidad no hay a quién contestarle. Mejor callar que adivinar.
+        assert mensajes_del_despacho({"messages": [{"id": "m", "text": "hola"}]}) == []
+
+    def test_un_mensaje_basura_no_tumba_la_rafaga(self) -> None:
+        msgs = mensajes_del_despacho(
+            {
+                "contact": {"identity": IDENTITY},
+                "messages": ["esto no es un mensaje", {"id": "m", "text": "hola"}],
+            }
+        )
+        assert len(msgs) == 1
+
+
+# ── Traducciones de forma ─────────────────────────────────────────────────
+
+
+class TestFormas:
+    def test_el_perfil_sale_del_contexto(self) -> None:
+        # En esta superficie el perfil no tiene endpoint propio: viaja dentro
+        # del contexto de la conversación.
+        p = _perfil_desde_contexto(
+            {
+                "agent": {"name": "Nea", "tone": "cercano"},
+                "knowledge": [{"question": "¿precio?", "answer": "500"}],
+            }
+        )
+        assert p["profile"]["name"] == "Nea"
+        assert "¿precio?" in p["kb"] and "500" in p["kb"]
+
+    def test_sin_conocimiento_el_kb_es_None(self) -> None:
+        # None y no "": el prompt distingue "no hay conocimiento" de un bloque
+        # vacío, y un string vacío lo haría escribir una sección en blanco.
+        assert _perfil_desde_contexto({"agent": {}, "knowledge": []})["kb"] is None
+
+    def test_ignora_bloques_a_medias(self) -> None:
+        p = _perfil_desde_contexto(
+            {"knowledge": [{"question": "¿precio?"}, {"answer": "suelto"}]}
+        )
+        assert p["kb"] is None
+
+    def test_la_reserva_se_aplana(self) -> None:
+        # El resto de Nea no debe saber por qué superficie entró la respuesta.
+        r = _aplanar_reserva(
+            {"ok": True, "booking": {"id": "bk_1", "label": "lunes 11:00"}}
+        )
+        assert r["label"] == "lunes 11:00" and r["id"] == "bk_1"
+
+    def test_aplanar_tolera_una_respuesta_inesperada(self) -> None:
+        assert _aplanar_reserva({"ok": True})["ok"] is True
+
+
+# ── El cliente ────────────────────────────────────────────────────────────
+
+
+@pytest.fixture
+def cliente() -> BrainsCrmClient:
+    return BrainsCrmClient(CRM_URL, SECRETO, "mi-negocio")
+
+
+class TestCliente:
+    @respx.mock
+    async def test_habla_con_brains_y_autentica_con_el_secreto(
+        self, cliente: BrainsCrmClient
+    ) -> None:
+        ruta = respx.post(f"{CRM_URL}/api/brains/messages").mock(
+            return_value=httpx.Response(200, json={"ok": True})
+        )
+        await cliente.send_message(CONV, "hola")
+
+        pedido = ruta.calls.last.request
+        assert pedido.headers["authorization"] == f"Bearer {SECRETO}"
+        assert pedido.headers["x-vocero-organization"] == "mi-negocio"
+
+    @respx.mock
+    async def test_el_contexto_va_por_conversacion_no_por_telefono(
+        self, cliente: BrainsCrmClient
+    ) -> None:
+        # `/api/brains/context` no acepta waIdentity: el ámbito de un cerebro
+        # es su organización, y buscar por teléfono sería una forma de
+        # preguntar por gente que no le corresponde.
+        ruta = respx.get(f"{CRM_URL}/api/brains/context").mock(
+            return_value=httpx.Response(
+                200, json={"conversation": {"id": CONV}, "agent": {"name": "Nea"}}
+            )
+        )
+        cliente.registrar(IDENTITY, CONV)
+        ctx = await cliente.get_context(IDENTITY)
+
+        assert ctx is not None
+        assert ruta.calls.last.request.url.params["conversationId"] == CONV
+
+    async def test_sin_despacho_previo_no_hay_contexto(
+        self, cliente: BrainsCrmClient
+    ) -> None:
+        # Sin conversación conocida se calla, igual que el camino de siempre
+        # cuando el CRM no conoce la identidad. No inventa.
+        assert await cliente.get_context("525559999999") is None
+
+    @respx.mock
+    async def test_el_perfil_no_gasta_una_llamada_de_mas(
+        self, cliente: BrainsCrmClient
+    ) -> None:
+        ruta = respx.get(f"{CRM_URL}/api/brains/context").mock(
+            return_value=httpx.Response(
+                200,
+                json={
+                    "conversation": {"id": CONV},
+                    "agent": {"name": "Nea", "tone": "cercano"},
+                    "knowledge": [],
+                },
+            )
+        )
+        cliente.registrar(IDENTITY, CONV)
+        await cliente.get_context(IDENTITY)
+        perfil = await cliente.get_profile()
+
+        assert perfil is not None and perfil["profile"]["name"] == "Nea"
+        assert ruta.call_count == 1  # el perfil vino con el contexto
+
+    @respx.mock
+    async def test_los_huecos_salen_de_la_agenda_del_crm(
+        self, cliente: BrainsCrmClient
+    ) -> None:
+        respx.get(f"{CRM_URL}/api/brains/agenda/slots").mock(
+            return_value=httpx.Response(
+                200,
+                json={
+                    "timezone": "America/Mexico_City",
+                    "durationMinutes": 30,
+                    "slots": [{"startUtc": "2026-09-01T17:00:00Z", "label": "lunes"}],
+                },
+            )
+        )
+        slots = await cliente.get_availability(CONV)
+        assert slots[0]["label"] == "lunes"
+
+    @respx.mock
+    async def test_reservar_devuelve_los_campos_al_ras(
+        self, cliente: BrainsCrmClient
+    ) -> None:
+        respx.post(f"{CRM_URL}/api/brains/agenda/book").mock(
+            return_value=httpx.Response(
+                201,
+                json={
+                    "ok": True,
+                    "booking": {
+                        "id": "bk_1",
+                        "label": "lunes 11:00",
+                        "meetingLink": "https://meet.test/x",
+                        "linkPending": False,
+                    },
+                },
+            )
+        )
+        r = await cliente.create_booking(CONV, "2026-09-01T17:00:00Z")
+        assert r["label"] == "lunes 11:00"
+        assert r["meetingLink"] == "https://meet.test/x"
+
+    @respx.mock
+    async def test_reprogramar_usa_PATCH_en_la_misma_ruta(
+        self, cliente: BrainsCrmClient
+    ) -> None:
+        # Es la MISMA cita. Si fuera otra ruta parecería que mover crea una
+        # segunda, y el cliente acabaría con dos horarios.
+        ruta = respx.patch(f"{CRM_URL}/api/brains/agenda/book").mock(
+            return_value=httpx.Response(200, json={"ok": True, "booking": {"id": "bk_1"}})
+        )
+        await cliente.reschedule_booking(CONV, "2026-09-01T18:00:00Z")
+        assert ruta.called
+
+    @respx.mock
+    async def test_la_agenda_apagada_se_reconoce(
+        self, cliente: BrainsCrmClient
+    ) -> None:
+        respx.get(f"{CRM_URL}/api/brains/agenda/slots").mock(
+            return_value=httpx.Response(404)
+        )
+        assert await cliente.agenda_available() is False
+
+    @respx.mock
+    async def test_si_el_crm_no_responde_se_asume_que_SI_agenda(
+        self, cliente: BrainsCrmClient
+    ) -> None:
+        # Prometer menos de lo que hay es tan malo como prometer de más: sin
+        # respuesta no se puede concluir que no haya agenda.
+        respx.get(f"{CRM_URL}/api/brains/agenda/slots").mock(
+            side_effect=httpx.ConnectError("sin red")
+        )
+        assert await cliente.agenda_available() is True
+
+    async def test_el_reset_de_pruebas_no_revienta(
+        self, cliente: BrainsCrmClient
+    ) -> None:
+        # No existe en esta superficie. Hacerlo estallar convertiría un comando
+        # de pruebas en una caída del turno.
+        await cliente.post_reset(CONV)


### PR DESCRIPTION
Con `VOCERO_MODE=cloud`, Nea sirve a muchos negocios desde una sola instancia y **cada uno trae su personalidad desde su propio CRM**.

## Lo primero: esto no rompe nada

Era la condición de partida, y así se cumplió:

- **Todo aditivo.** Sin la bandera, el webhook de Meta, el relay y `/api/bot/*` siguen exactamente igual.
- **Ninguna variable nueva es obligatoria.** Un contenedor que ya corre arranca sin tocar nada.
- **No se editó ni una de las 122 pruebas que ya existían.** Si hubiera tenido que hacerlo, eso mismo habría sido la señal de que rompí algo.

## Qué cambia con la bandera

**La entrada se invierte.** Hoy Meta le pega a Nea y Nea relaya al CRM. En cloud el CRM ya recibió el mensaje y se lo **despacha firmado** a `POST /vocero/dispatch`. Es una ruta nueva; el webhook de Meta no se toca.

**Sin relay** — el CRM ya tiene el mensaje; reenviárselo lo duplicaría en la bandeja del cliente.

**Sin coalesce propio** — el CRM ya esperó a que el cliente terminara de escribir y entrega la ráfaga junta. Volver a esperar aquí le sumaría segundos de silencio a alguien que ya esperó los del CRM.

**Otra superficie**: `/api/brains/*`, con el secreto de la organización en vez de `X-API-Key`. El CRM verifica que secreto y slug correspondan, así que un cerebro no actúa sobre otra organización aunque adivine el nombre.

El cliente nuevo hereda del de siempre y solo redefine lo que cambia de **forma**. Las rutas que solo cambian de sitio van en una tabla, para que cuando el contrato crezca se vea de un vistazo qué difiere de verdad.

## Dos detalles que no son obvios

**La firma se rechaza si NO hay secreto.** Al revés que el webhook de Meta, donde un secreto vacío significa «dev, no verifiques». Aquí el secreto es la única prueba de que quien despacha es el CRM y no cualquiera que conozca la URL.

**El dedup es por despacho, no por mensaje.** El CRM reintenta el despacho entero cuando no le acusamos recibo; contar sus mensajes uno por uno dejaría pasar el segundo intento con media ráfaga ya marcada.

## CI

El repositorio no tenía. Las pruebas dependían de que alguien se acordara de correrlas — y de aquí despliegan los miembros de la comunidad, así que un error en `main` les llega en su siguiente redespliegue.

Ahora corren en cada PR y en cada push a `main`, en Python 3.11 (la del Dockerfile: probar en otra versión es probar otra cosa).

## Pruebas

**151 verdes**: las 122 de antes intactas, más 29 nuevas sobre la bandera, la firma, la traducción del despacho y el cliente.

## Lo que falta para usarlo de verdad

Esto lo deja capaz; falta probarlo contra un Vocero cloud vivo — un mensaje real entrando por el despacho y una respuesta saliendo. Eso todavía no se ha hecho.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
