### PR TITLE
docs: una instancia de Nea por negocio, no una para todos

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,9 +73,15 @@ Meta ──► Vocero CRM (multitenant)
              └─ contesta por POST {CRM}/api/brains/* con ese mismo secreto
 ```
 
-Una sola Nea sirve a muchos negocios, y **cada uno trae su personalidad desde
-SU CRM**: nombre, tono, instrucciones y conocimiento salen del contexto de la
-conversación, no del código ni del brief local.
+**La misma Nea sirve a cualquier negocio sin tocarle una línea**: nombre, tono,
+instrucciones y conocimiento salen del contexto de la conversación, no del
+código ni del brief local. Cambiar el conocimiento en el CRM cambia lo que Nea
+responde, sin redesplegar nada.
+
+Pero **cada negocio corre su propia instancia**, con su secreto y su clave de
+LLM. No es una limitación: es lo que hace que el consumo de cada negocio lo
+pague su dueño y no quien hospeda. Una Nea compartida cargaría el gasto de
+todos a una sola cuenta.
 
 Sin la bandera no cambia nada: el webhook de Meta, el relay y `/api/bot/*`
 siguen siendo los de siempre. Las variables del modo cloud están en


### PR DESCRIPTION
Corrijo una frase mía del PR anterior que afirma más de lo que hace el código.

El README decía «una sola Nea sirve a muchos negocios». No es cierto: `CRM_BRAIN_SECRET` y `OPENAI_API_KEY` son valores únicos, así que **una instancia atiende a una organización**.

Y está bien que sea así. Una Nea compartida cargaría el gasto de LLM de todos los negocios a una sola cuenta — justo lo que el CRM evita dándole a cada organización su propio token.

Lo que sí es compartido, y es lo que importa, es el **código**: la misma imagen sirve a cualquier negocio sin tocarle una línea.

🤖 Generated with [Claude Code](https://claude.com/claude-code)