### PR TITLE
Una Nea para varios negocios, sin llevarse la llave de ninguno

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -143,10 +143,27 @@ LIVE_TARGET_NUMBER=REEMPLAZA_52XXXXXXXXXX
 # Nea deja de hablar con Meta directamente.
 VOCERO_MODE=
 
-# El secreto que genera el CRM en Ajustes → Cerebro. Firma lo que llega Y
-# autentica lo que sale: el mismo en las dos direcciones.
+# El secreto. De dónde sale depende de cuántos negocios atienda esta Nea:
+#
+#   UN negocio  → Ajustes → Cerebro del CRM, opción «mi propio agente».
+#   VARIOS      → del despliegue, que registra el dueño de la plataforma con
+#                 `pnpm cerebro:registrar` en el CRM. Ningún miembro lo ve.
+#
+# Firma lo que llega Y autentica lo que sale: el mismo en las dos direcciones.
 CRM_BRAIN_SECRET=
 
-# El slug de la organización ({slug}.tudominio.com). El CRM verifica que el
-# secreto y el slug correspondan, así que acertar uno sin el otro no sirve.
+# El slug de la organización ({slug}.tudominio.com).
+#
+# **VACÍO = MULTI-ORGANIZACIÓN.** Esta Nea deja de servir a un negocio y sirve
+# a todos los que el CRM le suscriba: cada despacho dice de quién es, y la
+# credencial para contestar se deriva del secreto de arriba. Es lo que evita
+# levantar un contenedor por miembro.
+#
+# En ese modo cada negocio pone SU llave de OpenRouter en su propio CRM y Nea
+# la recibe con el contexto de cada conversación: LLM_API_KEY de abajo NO se
+# usa, y si el CRM no la entrega, Nea se calla y deja la conversación a un
+# humano en vez de cobrarle a tu cuenta el consumo de todos.
+#
+# Con un slug puesto, el CRM verifica que el secreto y el slug correspondan,
+# así que acertar uno sin el otro no sirve.
 CRM_ORGANIZATION=

--- a/.env.example
+++ b/.env.example
@@ -159,10 +159,17 @@ CRM_BRAIN_SECRET=
 # credencial para contestar se deriva del secreto de arriba. Es lo que evita
 # levantar un contenedor por miembro.
 #
-# En ese modo cada negocio pone SU llave de OpenRouter en su propio CRM y Nea
-# la recibe con el contexto de cada conversación: LLM_API_KEY de abajo NO se
-# usa, y si el CRM no la entrega, Nea se calla y deja la conversación a un
-# humano en vez de cobrarle a tu cuenta el consumo de todos.
+# En ese modo **LLM_API_KEY, LLM_MODEL y LLM_BASE_URL de arriba NO se usan**.
+# Cada negocio pone su llave de OpenRouter en su propio CRM, y quien piensa es
+# el CRM: Nea le pide por /api/brains/llm y él le pone la credencial de esa
+# organización al reenviar al proveedor.
+#
+# Así la llave del miembro no llega nunca hasta aquí. Es a propósito: una
+# llave filtrada no se puede desfiltrar, y si el proveedor la rechaza conviene
+# que se entere el CRM, que es quien puede avisarle a su dueño.
+#
+# Si el CRM no ofrece pensar —este despliegue no es de confianza, o el miembro
+# no tiene token activo— Nea se calla y deja la conversación a un humano.
 #
 # Con un slug puesto, el CRM verifica que el secreto y el slug correspondan,
 # así que acertar uno sin el otro no sirve.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -19,6 +19,8 @@ idempotentes al arranque · httpx (CRM y OpenAI) · pytest + respx · Docker
 | La capa de persona del negocio | `app/profile.py` (CRM → brief local → mínimo) |
 | Las acciones del bot | `app/tools.py` + orquestación en `app/turn.py` |
 | El contrato con el CRM | `app/crm.py` (espejo del bot gateway de vocero) |
+| Vocero multitenant (modo cloud) | `app/dispatch.py` (entrada) · `app/crm_brains.py` (salida) |
+| Atender a VARIOS negocios a la vez | `app/multiorg.py` |
 | Webhook/firma/dedup/relay | `app/webhook.py` · `app/relay.py` |
 | Coalesce y seguimiento | `app/coalesce.py` · `app/followup.py` |
 | Tablas | `migrations/*.sql` (idempotentes, aplican al boot) |
@@ -32,6 +34,20 @@ idempotentes al arranque · httpx (CRM y OpenAI) · pytest + respx · Docker
   de prompt re-corre una verificación de comportamiento end-to-end.
 - **`ALLOWED_WA_IDS`**: con valor, solo se responde a esas identidades. No la
   vacíes sin decisión explícita del dueño de la instancia.
+- **Multi-organización** (`VOCERO_MODE=cloud` + `CRM_ORGANIZATION` vacía): una
+  Nea atiende a varios negocios. Tres reglas que no se negocian:
+  1. **La conversación es de (organización, identidad)**, nunca de la
+     identidad sola. La misma persona puede escribirle a dos negocios, y con
+     la clave global el historial de uno entraba en el prompt del otro.
+  2. **Sin la llave de IA del miembro NO se piensa** — ni en el turno ni en el
+     seguimiento. Caer a `LLM_API_KEY` del entorno le cobraría a la cuenta del
+     dueño de la plataforma el consumo de todos.
+  3. **`ctx.crm` y `ctx.llm` se arman por turno.** El del arranque es un
+     centinela que revienta al usarse: un camino que se olvide de armarlos
+     tiene que fallar, no escribirle al negocio equivocado.
+- **La credencial derivada es un contrato con el otro repositorio.** La cadena
+  `vocero:cerebro:v1` y el base64url sin relleno están fijados en pruebas a
+  ambos lados; desviarse un byte da 401 mudo en todo.
 - **Degradación silenciosa**: LLM/CRM fallando jamás rompe el webhook ni manda
   texto roto; tras reintentos → silencio + handoff `error`.
 - **La agenda la manda el CRM.** Vocero registra la oferta contra la

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -39,9 +39,14 @@ idempotentes al arranque · httpx (CRM y OpenAI) · pytest + respx · Docker
   1. **La conversación es de (organización, identidad)**, nunca de la
      identidad sola. La misma persona puede escribirle a dos negocios, y con
      la clave global el historial de uno entraba en el prompt del otro.
-  2. **Sin la llave de IA del miembro NO se piensa** — ni en el turno ni en el
-     seguimiento. Caer a `LLM_API_KEY` del entorno le cobraría a la cuenta del
-     dueño de la plataforma el consumo de todos.
+  2. **Quien piensa es el CRM**, no Nea. El cliente del modelo apunta a
+     `/api/brains/llm` con la credencial derivada, y el CRM le pone la llave
+     del miembro al reenviar. Si el CRM no ofrece pensar, NO se piensa — ni en
+     el turno ni en el seguimiento: caer a `LLM_API_KEY` del entorno le
+     cobraría al dueño de la plataforma el consumo de todos sus miembros.
+  2b. **Sin modelo que OIGA no se transcribe.** Caer al que conversa devuelve
+     una alucinación con pinta de transcripción, y quien la lee no tiene cómo
+     saber que es falsa.
   3. **`ctx.crm` y `ctx.llm` se arman por turno.** El del arranque es un
      centinela que revienta al usarse: un camino que se olvide de armarlos
      tiene que fallar, no escribirle al negocio equivocado.

--- a/README.md
+++ b/README.md
@@ -89,10 +89,12 @@ clave de LLM son los de él.
   todo despacho, y de él se **deriva** la credencial de cada negocio:
   `HMAC-SHA256(secreto, "vocero:cerebro:v1:{organizationId}")` en base64url.
   Nea la calcula; el CRM no se la manda.
-- **Cada negocio paga su propio consumo.** Su clave de OpenRouter y su modelo
-  llegan con el contexto de cada conversación, así que el gasto cae en la
-  cuenta de su dueño y no en la de quien hospeda. Sin esa clave Nea se calla y
-  deja la conversación a un humano, en vez de cobrarla a la cuenta equivocada.
+- **Cada negocio paga su propio consumo, y su clave no llega hasta aquí.**
+  Quien piensa es el CRM: Nea le pide por `/api/brains/llm` —un endpoint
+  compatible con OpenAI— y él le pone la credencial de esa organización al
+  reenviar al proveedor. Una llave que no viaja no se filtra, y cuando el
+  proveedor la rechaza el 401 lo recibe quien puede avisarle a su dueño.
+  Si el CRM no ofrece pensar, Nea se calla y deja la conversación a un humano.
 - **Las conversaciones no se cruzan.** La clave es (organización, identidad):
   la misma persona puede escribirle a dos negocios sin que el historial de uno
   aparezca en el prompt del otro.

--- a/README.md
+++ b/README.md
@@ -78,10 +78,28 @@ instrucciones y conocimiento salen del contexto de la conversación, no del
 código ni del brief local. Cambiar el conocimiento en el CRM cambia lo que Nea
 responde, sin redesplegar nada.
 
-Pero **cada negocio corre su propia instancia**, con su secreto y su clave de
-LLM. No es una limitación: es lo que hace que el consumo de cada negocio lo
-pague su dueño y no quien hospeda. Una Nea compartida cargaría el gasto de
-todos a una sola cuenta.
+#### Una instancia por negocio, o una para todos
+
+Con `CRM_ORGANIZATION` puesta, esta Nea sirve a ESE negocio: su secreto y su
+clave de LLM son los de él.
+
+**Déjala vacía y sirve a todos los que el CRM le suscriba.** Entonces:
+
+- El secreto es del **despliegue**, no de una organización. Con él se verifica
+  todo despacho, y de él se **deriva** la credencial de cada negocio:
+  `HMAC-SHA256(secreto, "vocero:cerebro:v1:{organizationId}")` en base64url.
+  Nea la calcula; el CRM no se la manda.
+- **Cada negocio paga su propio consumo.** Su clave de OpenRouter y su modelo
+  llegan con el contexto de cada conversación, así que el gasto cae en la
+  cuenta de su dueño y no en la de quien hospeda. Sin esa clave Nea se calla y
+  deja la conversación a un humano, en vez de cobrarla a la cuenta equivocada.
+- **Las conversaciones no se cruzan.** La clave es (organización, identidad):
+  la misma persona puede escribirle a dos negocios sin que el historial de uno
+  aparezca en el prompt del otro.
+
+El despliegue lo registra el dueño de la plataforma desde el CRM
+(`pnpm cerebro:registrar`), y cada miembro lo elige en Ajustes → Cerebro: sin
+URL que pegar ni secreto que copiar, porque el secreto no es suyo.
 
 Sin la bandera no cambia nada: el webhook de Meta, el relay y `/api/bot/*`
 siguen siendo los de siempre. Las variables del modo cloud están en

--- a/app/config.py
+++ b/app/config.py
@@ -110,8 +110,14 @@ class Settings(BaseSettings):
     #
     # `cloud` = Nea vive detrás de un Vocero multitenant: el CRM ya recibió el
     # mensaje y se lo DESPACHA a Nea firmado, y Nea contesta por
-    # `/api/brains/*`. Una sola Nea sirve a muchos negocios, y cada uno trae su
-    # personalidad desde SU CRM.
+    # `/api/brains/*`. Su personalidad y su conocimiento vienen de SU CRM.
+    #
+    # **Una instancia atiende a UNA organización.** `crm_brain_secret`,
+    # `crm_organization` y `llm_api_key` son valores únicos: un despacho de
+    # otra organización vendría firmado con otro secreto y se rechazaría con
+    # 401. Falla cerrado —no mezcla conversaciones ajenas ni le carga el token
+    # de un negocio a otro—, pero atender a varios negocios hoy significa una
+    # instancia por negocio.
     vocero_mode: str = ""
 
     # Secreto del cerebro, el que genera el CRM en Ajustes → Cerebro. Firma lo
@@ -121,6 +127,12 @@ class Settings(BaseSettings):
 
     # Slug de la organización. Solo se usa para acompañar al secreto; el CRM
     # verifica que coincidan, así que no sirve de nada acertar uno sin el otro.
+    #
+    # **VACÍA en modo cloud = multi-organización.** Entonces esta Nea no
+    # sirve a un negocio sino a todos los que el CRM le suscriba: cada
+    # despacho dice de quién es, y la credencial para contestar se DERIVA del
+    # secreto del despliegue (app/multiorg.py). Es lo que evita levantar un
+    # contenedor por negocio.
     crm_organization: str = ""
 
     # Infra
@@ -140,6 +152,17 @@ class Settings(BaseSettings):
         en vez de dejar que se descubra con un cliente esperando respuesta.
         """
         return bool(self.llm_base_url) and self.llm_transcribe_model == "whisper-1"
+
+    @property
+    def multi_org(self) -> bool:
+        """¿Esta Nea atiende a varias organizaciones?
+
+        Cloud + sin slug fijo. Se pide la ausencia de `crm_organization` y no
+        una bandera nueva porque las dos cosas se contradicen: un slug fijo
+        significa «solo este negocio», y una bandera aparte permitiría
+        pedir las dos a la vez y dejar sin definir cuál gana.
+        """
+        return self.cloud_mode and not self.crm_organization.strip()
 
     @property
     def cloud_mode(self) -> bool:

--- a/app/crm_brains.py
+++ b/app/crm_brains.py
@@ -71,10 +71,46 @@ class BrainsCrmClient(CrmClient):
         # turno — y para que el perfil sea el de la conversación que se está
         # atendiendo, no el de una petición suelta.
         self._perfil: dict[str, Any] | None = None
+        # Las credenciales de IA del MIEMBRO, tal como vinieron en el
+        # ultimo contexto. Solo llegan si el CRM considera de confianza a
+        # este despliegue; si no, se queda en None y el turno no corre.
+        self._llm: dict[str, Any] | None = None
+        # Contexto ya traido para una conversacion, pendiente de consumir.
+        # Lo llena `precargar` desde el despacho para que el turno no lo
+        # vuelva a pedir: una llamada HTTP por despacho, no dos.
+        self._precargado: dict[str, dict[str, Any]] = {}
 
     def registrar(self, identity: str, conversation_id: str) -> None:
         """Asocia una identidad con su conversación, desde el despacho."""
         self._conversaciones[identity] = conversation_id
+
+    async def precargar(self, conversation_id: str) -> dict[str, Any] | None:
+        """Trae el contexto AHORA y lo deja listo para el turno.
+
+        Existe por las credenciales de IA: el turno necesita saber con que
+        llave va a pensar ANTES de empezar a pensar, y esa llave viene en el
+        contexto. Sin esto habria que pedir el contexto dos veces por
+        despacho — una para las credenciales y otra dentro del turno.
+        """
+        resp = await self._request(
+            "GET", "/api/bot/context", params={"conversationId": conversation_id}
+        )
+        if resp.status_code != 200:
+            logger.warning(
+                "precarga del contexto de %s: el CRM respondio %s",
+                conversation_id,
+                resp.status_code,
+            )
+            return None
+        data: dict[str, Any] = resp.json()
+        self._perfil = _perfil_desde_contexto(data)
+        self._llm = data.get("llm") or None
+        self._precargado[conversation_id] = data
+        return data
+
+    def credenciales_llm(self) -> dict[str, Any] | None:
+        """Las del ultimo contexto. None = el CRM no las entrego."""
+        return self._llm
 
     def _request(self, method: str, url: str, **kwargs: Any):  # type: ignore[override]
         return super()._request(method, RUTAS.get(url, url), **kwargs)
@@ -98,6 +134,14 @@ class BrainsCrmClient(CrmClient):
             )
             return None
 
+        # Se consume UNA vez: asi el turno usa lo que ya se trajo en el
+        # despacho, pero un segundo turno de la misma conversacion vuelve a
+        # preguntar en vez de contestar con un contexto viejo.
+        precargado = self._precargado.pop(conversation_id, None)
+        if precargado is not None:
+            self._perfil = _perfil_desde_contexto(precargado)
+            return precargado
+
         resp = await self._request(
             "GET", "/api/bot/context", params={"conversationId": conversation_id}
         )
@@ -107,6 +151,7 @@ class BrainsCrmClient(CrmClient):
             raise CrmError(f"context devolvió {resp.status_code}")
         data: dict[str, Any] = resp.json()
         self._perfil = _perfil_desde_contexto(data)
+        self._llm = data.get("llm") or self._llm
         return data
 
     async def get_profile(self) -> dict[str, Any] | None:

--- a/app/crm_brains.py
+++ b/app/crm_brains.py
@@ -71,8 +71,9 @@ class BrainsCrmClient(CrmClient):
         # turno — y para que el perfil sea el de la conversación que se está
         # atendiendo, no el de una petición suelta.
         self._perfil: dict[str, Any] | None = None
-        # Las credenciales de IA del MIEMBRO, tal como vinieron en el
-        # ultimo contexto. Solo llegan si el CRM considera de confianza a
+        # Como puede pensar esta organizacion: la ruta por la que el CRM
+        # piensa por Nea, y que modelos acepta. NO trae ninguna llave — esa
+        # se queda en el CRM. Solo llega si el CRM considera de confianza a
         # este despliegue; si no, se queda en None y el turno no corre.
         self._llm: dict[str, Any] | None = None
         # Contexto ya traido para una conversacion, pendiente de consumir.
@@ -109,7 +110,12 @@ class BrainsCrmClient(CrmClient):
         return data
 
     def credenciales_llm(self) -> dict[str, Any] | None:
-        """Las del ultimo contexto. None = el CRM no las entrego."""
+        """La configuracion de IA del ultimo contexto.
+
+        None = el CRM no ofrece pensar por esta organizacion (este despliegue
+        no es de confianza, o el miembro no tiene token activo). Las dos se
+        tratan igual: sin turno, y la conversacion a un humano.
+        """
         return self._llm
 
     def _request(self, method: str, url: str, **kwargs: Any):  # type: ignore[override]

--- a/app/db.py
+++ b/app/db.py
@@ -41,6 +41,8 @@ def _conv_from_row(row: asyncpg.Record) -> Conversation:
         followup_sent=row["followup_sent"],
         last_inbound_at=row["last_inbound_at"],
         stalled_at=row["stalled_at"],
+        organization_id=row["organization_id"],
+        organization_slug=row["organization_slug"],
     )
 
 
@@ -112,6 +114,8 @@ class PgStore:
                 next_retry_at=r["next_retry_at"],
                 delivered_at=r["delivered_at"],
                 abandoned_at=r["abandoned_at"],
+                organization_id=r["organization_id"],
+                organization_slug=r["organization_slug"],
             )
             for r in rows
         ]
@@ -138,14 +142,31 @@ class PgStore:
 
     # ----------------------------------------------------- conversaciones ---
 
-    async def get_or_create_conversation(self, wa_identity: str) -> Conversation:
+    async def get_or_create_conversation(
+        self,
+        wa_identity: str,
+        organization_id: str = "",
+        organization_slug: str = "",
+    ) -> Conversation:
+        # El conflicto se resuelve contra (organization_id, wa_identity): la
+        # identidad sola dejó de identificar una conversación en cuanto una
+        # Nea atiende a varios negocios. Ver migrations/004_multiorg.sql.
+        #
+        # El slug se refresca en cada choque porque puede cambiar (un miembro
+        # renombra su subdominio) mientras el id no; guardarlo desactualizado
+        # haría que el worker de fondo hablara con una cabecera vieja.
         row = await self.pool.fetchrow(
             """
-            INSERT INTO bot_conversation (wa_identity) VALUES ($1)
-            ON CONFLICT (wa_identity) DO UPDATE SET updated_at = now()
+            INSERT INTO bot_conversation
+              (wa_identity, organization_id, organization_slug)
+            VALUES ($1, $2, $3)
+            ON CONFLICT (organization_id, wa_identity) DO UPDATE
+              SET updated_at = now(), organization_slug = EXCLUDED.organization_slug
             RETURNING *
             """,
             wa_identity,
+            organization_id,
+            organization_slug,
         )
         assert row is not None
         return _conv_from_row(row)
@@ -276,16 +297,25 @@ class PgStore:
     # ------------------------------------------------- envíos pendientes ---
 
     async def enqueue_pending_send(
-        self, conversation_id: int, crm_conversation_id: str, content: str
+        self,
+        conversation_id: int,
+        crm_conversation_id: str,
+        content: str,
+        organization_id: str = "",
+        organization_slug: str = "",
     ) -> int:
         row = await self.pool.fetchrow(
             """
-            INSERT INTO pending_send (conversation_id, crm_conversation_id, content)
-            VALUES ($1, $2, $3) RETURNING id
+            INSERT INTO pending_send
+              (conversation_id, crm_conversation_id, content,
+               organization_id, organization_slug)
+            VALUES ($1, $2, $3, $4, $5) RETURNING id
             """,
             conversation_id,
             crm_conversation_id,
             content,
+            organization_id,
+            organization_slug,
         )
         assert row is not None
         return row["id"]

--- a/app/dispatch.py
+++ b/app/dispatch.py
@@ -24,11 +24,13 @@ import hashlib
 import hmac
 import json
 import logging
+from dataclasses import replace
 from typing import Any
 
 from fastapi import APIRouter, Request
 from fastapi.responses import JSONResponse
 
+from app.multiorg import organizacion_del_despacho
 from app.state import AppContext, InboundMessage
 from app.turn import handle_flush
 
@@ -142,11 +144,95 @@ async def _procesar(ctx: AppContext, payload: dict[str, Any]) -> None:
             logger.info("dedup: despacho %s ya procesado — ignorado", dispatch_id)
             return
 
-    # El CRM ya sabe de quién es esta conversación; el cliente lo recuerda para
-    # no tener que preguntarlo por teléfono, que en esta superficie ni se puede.
-    registrar = getattr(ctx.crm, "registrar", None)
-    if callable(registrar):
-        registrar(identity, conversation_id)
+    if ctx.settings.multi_org:
+        ctx_turno = await _contexto_multiorg(ctx, payload, identity, conversation_id)
+        if ctx_turno is None:
+            return  # el motivo ya quedó en el log, y la conversación con humano
+    else:
+        # El CRM ya sabe de quién es esta conversación; el cliente lo recuerda
+        # para no preguntarlo por teléfono, que en esta superficie ni se puede.
+        registrar = getattr(ctx.crm, "registrar", None)
+        if callable(registrar):
+            registrar(identity, conversation_id)
+        ctx_turno = ctx
 
     # Directo al turno, sin coalescer: el CRM ya agrupó la ráfaga.
-    await handle_flush(ctx, identity, mensajes)
+    await handle_flush(ctx_turno, identity, mensajes)
+
+
+async def _contexto_multiorg(
+    ctx: AppContext,
+    payload: dict[str, Any],
+    identity: str,
+    conversation_id: str,
+) -> AppContext | None:
+    """El contexto de ESTE turno, con las credenciales de SU organización.
+
+    Una Nea multi-organización no puede tener un CRM ni un modelo fijos: el
+    cliente del CRM lleva la credencial de una organización concreta, y el
+    modelo se paga con la llave de ese miembro. Los dos se arman aquí y viven
+    lo que vive el turno.
+
+    Devuelve None cuando el turno NO debe correr. Los motivos se tratan igual
+    —silencio y la conversación en manos de un humano— porque desde el lado
+    del cliente son lo mismo: nadie le contestó, y alguien tiene que hacerlo.
+    """
+    registro = ctx.registro
+    if registro is None:
+        logger.error("modo multi-organización sin registro: no puedo contestar")
+        return None
+
+    org = organizacion_del_despacho(payload)
+    if org is None:
+        logger.warning("despacho sin organización en el cuerpo — ¿un CRM viejo?")
+        return None
+    org_id, slug = org
+
+    cliente = registro.cliente(org_id, slug)
+    cliente.registrar(identity, conversation_id)
+
+    # El contexto se trae AQUÍ y no dentro del turno porque de él salen las
+    # credenciales con las que el turno va a pensar. El turno lo reutiliza:
+    # `precargar` lo deja servido y `get_context` lo consume sin otra llamada.
+    contexto = await cliente.precargar(conversation_id)
+    if contexto is None:
+        logger.warning(
+            "%s: el CRM no dio contexto de %s — sin turno", slug, conversation_id
+        )
+        await _a_humano(cliente, conversation_id)
+        return None
+
+    credenciales = cliente.credenciales_llm()
+    if not credenciales or not credenciales.get("apiKey"):
+        # Sin llave del miembro NO se piensa. Caer a la del entorno sería
+        # cobrarle a la cuenta del dueño de la plataforma el consumo de todos
+        # sus miembros — exactamente lo que este modo existe para evitar.
+        logger.warning(
+            "%s: sin credenciales de IA para %s; token inactivo o "
+            "despliegue no confiable — sin turno",
+            slug,
+            conversation_id,
+        )
+        await _a_humano(cliente, conversation_id)
+        return None
+
+    return replace(
+        ctx,
+        crm=cliente,
+        llm=registro.llm(credenciales, ctx.settings),
+        profile=registro.perfil(org_id, slug),
+        organizacion=(org_id, slug),
+    )
+
+
+async def _a_humano(cliente: Any, conversation_id: str) -> None:
+    """Marca la conversación para un humano, sin que eso pueda tumbar nada.
+
+    Si hasta el handoff falla ya solo queda el log: el mensaje del cliente está
+    guardado en la bandeja del CRM desde antes de que Nea lo viera, así que no
+    se pierde nada aunque esta llamada no llegue.
+    """
+    try:
+        await cliente.post_handoff(conversation_id, "error")
+    except Exception:
+        logger.exception("no pude marcar %s para humano", conversation_id)

--- a/app/dispatch.py
+++ b/app/dispatch.py
@@ -202,13 +202,15 @@ async def _contexto_multiorg(
         await _a_humano(cliente, conversation_id)
         return None
 
-    credenciales = cliente.credenciales_llm()
-    if not credenciales or not credenciales.get("apiKey"):
-        # Sin llave del miembro NO se piensa. Caer a la del entorno sería
-        # cobrarle a la cuenta del dueño de la plataforma el consumo de todos
-        # sus miembros — exactamente lo que este modo existe para evitar.
+    config_ia = cliente.credenciales_llm()
+    if not config_ia:
+        # El CRM no ofrece pensar por esta organización. O este despliegue no
+        # es de confianza, o el miembro no tiene token activo. En los dos
+        # casos hay que callarse: pensar con la llave del entorno le cobraría
+        # a la cuenta del dueño de la plataforma el consumo de sus miembros,
+        # que es justo lo que este modo existe para evitar.
         logger.warning(
-            "%s: sin credenciales de IA para %s; token inactivo o "
+            "%s: el CRM no ofrece IA para %s; token inactivo o "
             "despliegue no confiable — sin turno",
             slug,
             conversation_id,
@@ -219,7 +221,7 @@ async def _contexto_multiorg(
     return replace(
         ctx,
         crm=cliente,
-        llm=registro.llm(credenciales, ctx.settings),
+        llm=registro.llm(org_id, slug, config_ia, ctx.settings),
         profile=registro.perfil(org_id, slug),
         organizacion=(org_id, slug),
     )

--- a/app/followup.py
+++ b/app/followup.py
@@ -120,18 +120,27 @@ class FollowupWorker:
             )
             return
 
-        # El empujón se piensa con la llave de SU miembro, igual que el turno.
-        # Sin ella no se piensa: cobrarle a la cuenta del dueño de la
-        # plataforma es justo lo que el modo multi-organización evita.
+        # El empujón se piensa a cuenta de SU miembro, igual que el turno: por
+        # el CRM, con la credencial de esta organización. Si el CRM no ofrece
+        # pensar, no se piensa — usar la llave del entorno le cobraría al
+        # dueño de la plataforma el consumo de sus miembros.
         if ctx.settings.multi_org:
-            credenciales = getattr(ctx.crm, "credenciales_llm", lambda: None)()
-            if not credenciales or not credenciales.get("apiKey"):
+            config_ia = getattr(ctx.crm, "credenciales_llm", lambda: None)()
+            if not config_ia:
                 logger.warning(
-                    "followup %s: sin credenciales de IA — omitido",
+                    "followup %s: el CRM no ofrece IA — omitido",
                     conv.wa_identity,
                 )
                 return
-            ctx = replace(ctx, llm=ctx.registro.llm(credenciales, ctx.settings))
+            ctx = replace(
+                ctx,
+                llm=ctx.registro.llm(
+                    conv.organization_id,
+                    conv.organization_slug,
+                    config_ia,
+                    ctx.settings,
+                ),
+            )
 
         system = build_system_prompt(
             profile=await resolve_profile(ctx),

--- a/app/followup.py
+++ b/app/followup.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 import asyncio
 import logging
+from dataclasses import replace
 from datetime import datetime
 from typing import Any
 
@@ -17,6 +18,7 @@ from app.llm import LlmExhausted
 from app.profile import resolve_profile
 from app.prompt import FOLLOWUP_INSTRUCTION, build_system_prompt
 from app.state import AppContext, Conversation, utcnow
+from app.multiorg import ctx_de_organizacion
 from app.turn import conversation_lock
 from app.turn import _agent_tz
 
@@ -50,8 +52,20 @@ class FollowupWorker:
                 # el Store puede devolver el mismo objeto vivo (MemoryStore) y
                 # compararlo contra sí mismo no detectaría nada.
                 ultimo_inbound = conv.last_inbound_at
+                # De quién es esta conversación. El seguimiento despierta
+                # horas después del turno, cuando ya no hay despacho del que
+                # sacarlo: sale de la fila misma.
+                ctx = ctx_de_organizacion(
+                    self._ctx, conv.organization_id, conv.organization_slug
+                )
+                if ctx is None:
+                    logger.error(
+                        "followup %s: sin organización conocida — omitido",
+                        conv.wa_identity,
+                    )
+                    continue
                 async with conversation_lock(self._ctx, conv.wa_identity):
-                    await self._push(conv, ultimo_inbound)
+                    await self._push(ctx, conv, ultimo_inbound)
             except Exception:
                 logger.exception(
                     "followup de %s falló — queda consumido (a lo sumo uno)",
@@ -59,18 +73,30 @@ class FollowupWorker:
                 )
 
     async def _push(
-        self, conv: Conversation, ultimo_inbound: datetime | None
+        self,
+        ctx: AppContext,
+        conv: Conversation,
+        ultimo_inbound: datetime | None,
     ) -> None:
-        ctx = self._ctx
         # Si mientras esperábamos el candado el lead escribió, el empujón sobra:
         # ya hay conversación viva y "¿seguimos?" quedaría fuera de lugar.
-        fresca = await ctx.store.get_or_create_conversation(conv.wa_identity)
+        fresca = await ctx.store.get_or_create_conversation(
+            conv.wa_identity, conv.organization_id, conv.organization_slug
+        )
         if fresca.last_inbound_at != ultimo_inbound:
             logger.info(
                 "followup %s: el lead escribió mientras tanto — omitido",
                 conv.wa_identity,
             )
             return
+        # Tras un reinicio, el cliente del CRM no recuerda qué conversación
+        # es cuál —esa memoria la llena el despacho, y aquí no hay despacho—,
+        # así que se la devolvemos desde lo que Nea sí guardó. Sin esto, todo
+        # seguimiento posterior a un redespliegue se omitía por "sin contexto".
+        registrar = getattr(ctx.crm, "registrar", None)
+        if callable(registrar) and conv.crm_conversation_id:
+            registrar(conv.wa_identity, conv.crm_conversation_id)
+
         try:
             context = await ctx.crm.get_context(conv.wa_identity)
         except CrmError as exc:
@@ -93,6 +119,19 @@ class FollowupWorker:
                 conv.wa_identity,
             )
             return
+
+        # El empujón se piensa con la llave de SU miembro, igual que el turno.
+        # Sin ella no se piensa: cobrarle a la cuenta del dueño de la
+        # plataforma es justo lo que el modo multi-organización evita.
+        if ctx.settings.multi_org:
+            credenciales = getattr(ctx.crm, "credenciales_llm", lambda: None)()
+            if not credenciales or not credenciales.get("apiKey"):
+                logger.warning(
+                    "followup %s: sin credenciales de IA — omitido",
+                    conv.wa_identity,
+                )
+                return
+            ctx = replace(ctx, llm=ctx.registro.llm(credenciales, ctx.settings))
 
         system = build_system_prompt(
             profile=await resolve_profile(ctx),

--- a/app/llm.py
+++ b/app/llm.py
@@ -82,12 +82,18 @@ class OpenAiLlm:
         model: str,
         transcribe_model: str = "whisper-1",
         base_url: str | None = None,
+        default_headers: dict[str, str] | None = None,
     ) -> None:
         # base_url ≠ None → proveedor OpenAI-compatible (p. ej. OpenRouter,
         # para el bench de modelos del 002). Ojo: la transcripción de audio
         # es una API de OpenAI — con otro proveedor degrada honesta
         # (LlmExhausted → fallback), por eso el bench alterno cubre texto.
-        self._client = AsyncOpenAI(api_key=api_key, base_url=base_url)
+        # `default_headers` lo usa el modo multi-organización: cuando quien
+        # piensa es el CRM (y no OpenRouter directo), hay que decirle de qué
+        # organización es cada llamada.
+        self._client = AsyncOpenAI(
+            api_key=api_key, base_url=base_url, default_headers=default_headers
+        )
         self._model = model
         self._transcribe_model = transcribe_model
         # Con proveedor propio (OpenRouter y compañía) no hay endpoint de
@@ -112,6 +118,13 @@ class OpenAiLlm:
           audio. Ojo: el modelo que conversa y el que oye no tienen por qué
           ser el mismo — hoy los GLM, por ejemplo, no oyen.
         """
+        # Sin modelo que oiga no se intenta siquiera. Mandar el audio al que
+        # conversa devolvería una alucinación con pinta de transcripción, que
+        # es peor que decir que no se pudo: quien la lee no sabe que es falsa.
+        if not self._transcribe_model:
+            raise LlmExhausted(
+                "sin modelo de transcripción configurado — no se transcribe"
+            )
         if self._audio_por_chat:
             return await self._transcribir_por_chat(data, mime)
         last_error: Exception | None = None

--- a/app/main.py
+++ b/app/main.py
@@ -25,6 +25,7 @@ from app.dispatch import router as dispatch_router
 from app.db import PgStore
 from app.followup import FollowupWorker
 from app.llm import OpenAiLlm
+from app.multiorg import CrmSinOrganizacion, RegistroDeOrganizaciones
 from app.profile import ProfileProvider
 from app.relay import RelayWorker
 from app.sender import SenderWorker
@@ -58,17 +59,31 @@ def create_app(ctx: AppContext | None = None) -> FastAPI:
             await store.connect()
             await store.migrate(MIGRATIONS_DIR)
             logger.info("migraciones aplicadas — DB lista")
-            # Modo cloud: otra superficie del CRM y otra autenticación. Sin la
-            # bandera, exactamente el cliente de siempre.
-            crm = (
-                BrainsCrmClient(
+            # Tres modos, y solo el primero es nuevo:
+            #
+            # - multi-organización: no hay cliente fijo. Cada turno arma el
+            #   suyo con la credencial derivada de SU organización, y el
+            #   centinela hace que un camino que se olvide de armarlo
+            #   reviente en vez de escribirle al negocio equivocado.
+            # - cloud de un negocio: el cliente de una sola organización.
+            # - sin bandera: exactamente lo de toda la vida.
+            registro = None
+            if settings.multi_org:
+                registro = RegistroDeOrganizaciones(
+                    settings.crm_base_url,
+                    settings.crm_brain_secret,
+                    nombre_por_defecto=settings.agent_name,
+                    brief_path=settings.brief_path or None,
+                )
+                crm = CrmSinOrganizacion()
+            elif settings.cloud_mode:
+                crm = BrainsCrmClient(
                     settings.crm_base_url,
                     settings.crm_brain_secret,
                     settings.crm_organization,
                 )
-                if settings.cloud_mode
-                else CrmClient(settings.crm_base_url, settings.crm_bot_api_key)
-            )
+            else:
+                crm = CrmClient(settings.crm_base_url, settings.crm_bot_api_key)
             app.state.ctx = AppContext(
                 settings=settings,
                 store=store,
@@ -79,11 +94,19 @@ def create_app(ctx: AppContext | None = None) -> FastAPI:
                     transcribe_model=settings.llm_transcribe_model,
                     base_url=settings.llm_base_url or None,
                 ),
-                profile=ProfileProvider(
-                    crm,
-                    default_name=settings.agent_name,
-                    brief_path=settings.brief_path or None,
+                # En multi-organización el perfil es de cada negocio y lo
+                # sirve el registro; un proveedor global aquí serviría el
+                # perfil de uno a todos.
+                profile=(
+                    None
+                    if settings.multi_org
+                    else ProfileProvider(
+                        crm,
+                        default_name=settings.agent_name,
+                        brief_path=settings.brief_path or None,
+                    )
                 ),
+                registro=registro,
             )
         c: AppContext = app.state.ctx
         _wire_coalescer(c)
@@ -124,7 +147,11 @@ def create_app(ctx: AppContext | None = None) -> FastAPI:
             )
         logger.info(
             "Nea arriba (%s): %sfollowup + sender corriendo",
-            "cloud" if c.settings.cloud_mode else "meta",
+            (
+                "cloud multi-organización"
+                if c.settings.multi_org
+                else "cloud" if c.settings.cloud_mode else "meta"
+            ),
             "" if c.settings.cloud_mode else "relay + ",
         )
         try:
@@ -138,6 +165,8 @@ def create_app(ctx: AppContext | None = None) -> FastAPI:
                 await c.coalescer.aclose()
             if own_resources:
                 await c.crm.aclose()
+                if c.registro is not None:
+                    await c.registro.aclose()
                 await c.store.aclose()
 
     app = FastAPI(title="Nea — agente de agendamiento para WhatsApp", lifespan=lifespan)

--- a/app/multiorg.py
+++ b/app/multiorg.py
@@ -25,11 +25,19 @@ Derivarla en vez de recibirla tiene una consecuencia práctica que importa: un
 worker de seguimiento que despierta cuatro horas después la vuelve a calcular
 igual. No hay token que caduque a media conversación ni credencial que guardar.
 
-## Lo que NO viene por aquí
+## Con qué piensa
 
-La llave de OpenRouter. Esa viaja en el contexto de cada conversación
-(`/api/brains/context`), porque es del MIEMBRO y cambia según a quién se esté
-atendiendo. Ver `crm_brains.py`.
+**No con una llave propia, y tampoco con la del miembro.** El CRM piensa por
+Nea: `/api/brains/llm` es un endpoint compatible con OpenAI que le pone la
+credencial de esa organización y reenvía al proveedor.
+
+Así la llave del miembro no sale nunca del CRM —una filtrada no se puede
+desfiltrar— y, de paso, cuando el proveedor la rechaza es el CRM quien recibe
+el 401 y puede pausarla en el panel de su dueño. Cuando la llave viajaba, ese
+código se lo comía Nea y el miembro veía «activa» mientras nada funcionaba.
+
+Del contexto de cada conversación sale la ruta y qué modelos puede usar. Ver
+`crm_brains.py`.
 """
 from __future__ import annotations
 
@@ -95,9 +103,9 @@ class RegistroDeOrganizaciones:
         self._brief = brief_path
         self._clientes: dict[str, BrainsCrmClient] = {}
         self._perfiles: dict[str, ProfileProvider] = {}
-        # Cacheados por CREDENCIAL y no por organizacion: si el miembro rota
-        # su llave o cambia de modelo, la tupla cambia y el siguiente turno
-        # ya usa el cliente nuevo sin que nadie tenga que invalidar nada.
+        # Cacheados por la tupla completa y no por organizacion: si el miembro
+        # cambia de modelo, la tupla cambia y el siguiente turno ya usa el
+        # cliente nuevo sin que nadie tenga que invalidar nada.
         self._llms: dict[tuple[str, str, str, str], OpenAiLlm] = {}
 
     def cliente(self, organization_id: str, slug: str) -> BrainsCrmClient:
@@ -132,29 +140,42 @@ class RegistroDeOrganizaciones:
             self._perfiles[organization_id] = proveedor
         return proveedor
 
-    def llm(self, credenciales: dict[str, Any], por_defecto: Any) -> OpenAiLlm:
-        """El cliente del modelo con la llave del MIEMBRO.
+    def llm(
+        self,
+        organization_id: str,
+        slug: str,
+        config: dict[str, Any],
+        por_defecto: Any,
+    ) -> OpenAiLlm:
+        """El cliente del modelo, apuntando al CRM.
 
-        `por_defecto` son los ajustes de esta Nea, y solo rellenan los huecos:
-        si el miembro no eligio modelo, se usa el de la instancia. La LLAVE
-        nunca se rellena — sin llave del miembro no hay turno, porque
-        pensar con la del duenio de la plataforma es justo el gasto que este
-        modo existe para evitar.
+        No lleva la llave de nadie: lleva la credencial derivada de esta
+        organización, la misma con la que Nea le habla al CRM para todo lo
+        demás. El CRM le pone la llave del miembro al reenviar al proveedor.
+
+        Para el SDK de OpenAI esto es un proveedor compatible más. Por eso el
+        cambio cabe aquí y no se nota en el resto del turno.
+
+        `por_defecto` son los ajustes de esta Nea y solo rellenan el modelo
+        que conversa. El que TRANSCRIBE no se rellena: si el miembro no
+        eligió uno que oiga, es mejor no transcribir que mandarle el audio a
+        uno que no oye y quedarnos con lo que invente.
         """
-        api_key = str(credenciales.get("apiKey") or "")
-        model = str(credenciales.get("model") or por_defecto.llm_model)
-        transcribe = str(
-            credenciales.get("transcribeModel") or por_defecto.llm_transcribe_model
+        base_url = self._base_url.rstrip("/") + str(
+            config.get("path") or "/api/brains/llm"
         )
-        base_url = str(credenciales.get("baseUrl") or por_defecto.llm_base_url or "")
-        clave = (api_key, model, transcribe, base_url)
+        model = str(config.get("model") or por_defecto.llm_model)
+        transcribe = str(config.get("transcribeModel") or "")
+        credencial = credencial_derivada(self._secreto, organization_id)
+        clave = (credencial, model, transcribe, base_url)
         cliente = self._llms.get(clave)
         if cliente is None:
             cliente = OpenAiLlm(
-                api_key,
+                credencial,
                 model,
                 transcribe_model=transcribe,
-                base_url=base_url or None,
+                base_url=base_url,
+                default_headers={"X-Vocero-Organization": slug},
             )
             self._llms[clave] = cliente
         return cliente

--- a/app/multiorg.py
+++ b/app/multiorg.py
@@ -1,0 +1,251 @@
+"""Modo multi-organización: una Nea atendiendo a varios negocios.
+
+## El problema que resuelve
+
+En modo cloud, Nea atendía a UNA organización: `CRM_BRAIN_SECRET`,
+`CRM_ORGANIZATION` y `LLM_API_KEY` son valores únicos. Servir a diez negocios
+significaba levantar diez Neas.
+
+El atajo evidente —el mismo secreto para todas las organizaciones del CRM—
+rompe el aislamiento del lado del CRM: allá cada miembro puede ver su secreto,
+y con uno compartido cualquiera escribiría en la bandeja de otro.
+
+## Cómo funciona
+
+El CRM registra a esta Nea como un *despliegue* con UN secreto que ningún
+miembro ve. Ese secreto:
+
+1. **Firma los despachos.** Todos, sea cual sea la organización, así que se
+   verifican con uno solo — que es lo que permite atenderlas a todas.
+2. **Deriva la credencial de cada organización** para contestar:
+
+       credencial(org) = HMAC-SHA256(secreto, "vocero:cerebro:v1:{org_id}")
+
+Derivarla en vez de recibirla tiene una consecuencia práctica que importa: un
+worker de seguimiento que despierta cuatro horas después la vuelve a calcular
+igual. No hay token que caduque a media conversación ni credencial que guardar.
+
+## Lo que NO viene por aquí
+
+La llave de OpenRouter. Esa viaja en el contexto de cada conversación
+(`/api/brains/context`), porque es del MIEMBRO y cambia según a quién se esté
+atendiendo. Ver `crm_brains.py`.
+"""
+from __future__ import annotations
+
+import base64
+import hashlib
+import hmac
+import logging
+from dataclasses import replace
+from typing import TYPE_CHECKING, Any
+
+from app.crm_brains import BrainsCrmClient
+from app.llm import OpenAiLlm
+from app.profile import ProfileProvider
+
+if TYPE_CHECKING:
+    from app.state import AppContext
+
+logger = logging.getLogger("nea.multiorg")
+
+# Separación de dominio. Tiene que ser EXACTAMENTE la misma cadena que usa
+# `src/server/brains/deployment.ts` en el CRM: es un contrato entre dos
+# repositorios, y un guion de diferencia lo rompe entero sin decir por qué.
+DOMINIO = "vocero:cerebro:v1"
+
+
+def credencial_derivada(secreto_despliegue: str, organization_id: str) -> str:
+    """La credencial de UNA organización dentro de este despliegue.
+
+    base64url SIN relleno: es lo que produce `.digest("base64url")` de Node, y
+    aquí se compara carácter a carácter contra lo que espera el CRM.
+    """
+    mac = hmac.new(
+        secreto_despliegue.encode(),
+        f"{DOMINIO}:{organization_id}".encode(),
+        hashlib.sha256,
+    ).digest()
+    return base64.urlsafe_b64encode(mac).rstrip(b"=").decode()
+
+
+class RegistroDeOrganizaciones:
+    """Un cliente del CRM por organización, creado a demanda.
+
+    Se cachean porque cada uno tiene su propio pool de conexiones HTTP: crear
+    uno por mensaje abriría y cerraría sockets en cada turno contra el mismo
+    CRM.
+
+    La caché es por `organization_id` y no por slug: el slug es lo que viaja en
+    la cabecera, pero el id es lo que firma la credencial. Si un miembro
+    renombrara su subdominio, la credencial seguiría siendo la correcta.
+    """
+
+    def __init__(
+        self,
+        base_url: str,
+        secreto_despliegue: str,
+        *,
+        nombre_por_defecto: str = "Nea",
+        brief_path: str | None = None,
+    ) -> None:
+        self._base_url = base_url
+        self._secreto = secreto_despliegue
+        self._nombre = nombre_por_defecto
+        self._brief = brief_path
+        self._clientes: dict[str, BrainsCrmClient] = {}
+        self._perfiles: dict[str, ProfileProvider] = {}
+        # Cacheados por CREDENCIAL y no por organizacion: si el miembro rota
+        # su llave o cambia de modelo, la tupla cambia y el siguiente turno
+        # ya usa el cliente nuevo sin que nadie tenga que invalidar nada.
+        self._llms: dict[tuple[str, str, str, str], OpenAiLlm] = {}
+
+    def cliente(self, organization_id: str, slug: str) -> BrainsCrmClient:
+        cliente = self._clientes.get(organization_id)
+        if cliente is None:
+            cliente = BrainsCrmClient(
+                self._base_url,
+                credencial_derivada(self._secreto, organization_id),
+                slug,
+            )
+            self._clientes[organization_id] = cliente
+            logger.info(
+                "organización %s (%s): cliente del CRM creado", slug, organization_id
+            )
+        return cliente
+
+    def perfil(self, organization_id: str, slug: str) -> ProfileProvider:
+        """El proveedor de perfil de esa organizacion, con su propia cache.
+
+        Uno por organizacion y no uno por turno: `ProfileProvider` cachea con
+        TTL, y rehacerlo en cada mensaje tiraria esa cache al suelo. Uno por
+        organizacion mantiene la cache Y garantiza que el perfil de un
+        negocio no se le sirva a otro.
+        """
+        proveedor = self._perfiles.get(organization_id)
+        if proveedor is None:
+            proveedor = ProfileProvider(
+                self.cliente(organization_id, slug),
+                default_name=self._nombre,
+                brief_path=self._brief,
+            )
+            self._perfiles[organization_id] = proveedor
+        return proveedor
+
+    def llm(self, credenciales: dict[str, Any], por_defecto: Any) -> OpenAiLlm:
+        """El cliente del modelo con la llave del MIEMBRO.
+
+        `por_defecto` son los ajustes de esta Nea, y solo rellenan los huecos:
+        si el miembro no eligio modelo, se usa el de la instancia. La LLAVE
+        nunca se rellena — sin llave del miembro no hay turno, porque
+        pensar con la del duenio de la plataforma es justo el gasto que este
+        modo existe para evitar.
+        """
+        api_key = str(credenciales.get("apiKey") or "")
+        model = str(credenciales.get("model") or por_defecto.llm_model)
+        transcribe = str(
+            credenciales.get("transcribeModel") or por_defecto.llm_transcribe_model
+        )
+        base_url = str(credenciales.get("baseUrl") or por_defecto.llm_base_url or "")
+        clave = (api_key, model, transcribe, base_url)
+        cliente = self._llms.get(clave)
+        if cliente is None:
+            cliente = OpenAiLlm(
+                api_key,
+                model,
+                transcribe_model=transcribe,
+                base_url=base_url or None,
+            )
+            self._llms[clave] = cliente
+        return cliente
+
+    async def aclose(self) -> None:
+        for cliente in self._clientes.values():
+            await cliente.aclose()
+        self._clientes.clear()
+        # Los perfiles y los LLM cuelgan de esos clientes: dejarlos vivos
+        # apuntando a conexiones cerradas es un fallo que solo aparece si la
+        # app se reinicia en caliente, y entonces cuesta encontrarlo.
+        self._perfiles.clear()
+        self._llms.clear()
+
+
+class CrmSinOrganizacion:
+    """El "cliente" del CRM mientras no se sabe de qué organización.
+
+    En modo multi-organización no existe un cliente del CRM por defecto: cada
+    turno arma el suyo con la credencial de la organización que le toca. Pero
+    `AppContext.crm` tiene que ser algo, y ese algo importa mucho.
+
+    Si fuera un cliente de verdad —el de la primera organización, digamos—, un
+    camino que se olvidara de cambiarlo escribiría en la bandeja EQUIVOCADA y
+    nadie se enteraría: el mensaje sale, el CRM lo acepta, y aparece en el
+    negocio que no era. Con esto, ese olvido revienta en el sitio exacto.
+
+    Las dos excepciones son las que usa el arranque y el apagado, y ninguna
+    escribe nada.
+    """
+
+    async def agenda_available(self) -> bool:
+        """No se sonda: no hay con qué credencial preguntar.
+
+        Se asume que sí, que es lo mismo que hace el sondeo cuando no puede
+        concluir. Si resulta que no, el primer intento real recibe 404 y las
+        herramientas de agenda contestan "aquí no se agenda" — un camino que ya
+        existe y está probado.
+        """
+        return True
+
+    async def aclose(self) -> None:
+        return None
+
+    def __getattr__(self, nombre: str) -> Any:
+        raise RuntimeError(
+            f"se intentó usar el CRM ({nombre}) sin saber de qué organización "
+            f"es este turno: en modo multi-organización el cliente lo arma el "
+            f"despacho, no el arranque"
+        )
+
+def ctx_de_organizacion(
+    ctx: "AppContext",
+    organization_id: str,
+    organization_slug: str,
+) -> "AppContext | None":
+    """El contexto de un worker de fondo, apuntando a UNA organización.
+
+    Los workers (seguimiento, envío diferido) despiertan mucho después del
+    turno, cuando ya no hay despacho del que sacar de quién era el mensaje. Lo
+    sacan de la fila que están procesando, que por eso guarda su organización.
+
+    Fuera del modo multi-organización devuelve el contexto tal cual: una Nea de
+    un solo negocio ya tiene el cliente correcto y no hay nada que resolver.
+
+    None significa «no puedo saber de quién es esto». Pasa con filas escritas
+    antes de esta versión, que no llevan organización. Callarse es lo correcto:
+    contestar con la credencial equivocada sería escribirle al negocio que no
+    era.
+    """
+    if not ctx.settings.multi_org:
+        return ctx
+    if not organization_id or ctx.registro is None:
+        return None
+    return replace(
+        ctx,
+        crm=ctx.registro.cliente(organization_id, organization_slug),
+        profile=ctx.registro.perfil(organization_id, organization_slug),
+        organizacion=(organization_id, organization_slug),
+    )
+
+def organizacion_del_despacho(payload: dict[str, Any]) -> tuple[str, str] | None:
+    """`(id, slug)` de la organización a la que pertenece este despacho.
+
+    El slug puede faltar —una organización recién creada podría no tenerlo— y
+    entonces se usa el id también como slug, que es lo que acepta el CRM en la
+    cabecera. El id, en cambio, es obligatorio: sin él no hay credencial que
+    derivar, y contestar sería imposible.
+    """
+    org = payload.get("organization") or {}
+    org_id = str(org.get("id") or "")
+    if not org_id:
+        return None
+    return org_id, str(org.get("slug") or org_id)

--- a/app/sender.py
+++ b/app/sender.py
@@ -14,6 +14,7 @@ import logging
 from datetime import datetime, timedelta
 
 from app.crm import CrmConflict, CrmError
+from app.multiorg import ctx_de_organizacion
 from app.state import AppContext, PendingSend, utcnow
 
 logger = logging.getLogger("nea.sender")
@@ -39,18 +40,33 @@ class SenderWorker:
     async def tick(self, now: datetime | None = None) -> None:
         now = now or utcnow()
         for item in await self._ctx.store.due_pending_sends(now):
+            # Con quién hay que hablar para ESTA fila. En una Nea de un solo
+            # negocio es siempre el mismo; en una multi-organización, el de
+            # la organización que dejó el envío pendiente.
+            ctx = ctx_de_organizacion(
+                self._ctx, item.organization_id, item.organization_slug
+            )
+            if ctx is None:
+                logger.error(
+                    "sender: pending %d sin organización conocida — no puedo "
+                    "entregarlo sin arriesgarme a escribirle a otro negocio",
+                    item.id,
+                )
+                await self._ctx.store.mark_pending_send_abandoned(item.id)
+                continue
             if now - item.created_at > self.MAX_AGE:
                 logger.error(
                     "sender: pending %d agotó las 24 h sin entregar — abandonado + handoff",
                     item.id,
                 )
                 await self._ctx.store.mark_pending_send_abandoned(item.id)
-                await self._handoff(item.crm_conversation_id)
+                await self._handoff(ctx, item.crm_conversation_id)
                 continue
-            await self._attempt(item, now)
+            await self._attempt(ctx, item, now)
 
-    async def _attempt(self, item: PendingSend, now: datetime) -> None:
-        ctx = self._ctx
+    async def _attempt(
+        self, ctx: AppContext, item: PendingSend, now: datetime
+    ) -> None:
         try:
             await ctx.crm.send_message(item.crm_conversation_id, item.content)
         except CrmConflict as exc:
@@ -81,8 +97,8 @@ class SenderWorker:
         await ctx.store.add_message(item.conversation_id, "assistant", item.content)
         logger.info("sender: pending %d entregado", item.id)
 
-    async def _handoff(self, crm_conv_id: str) -> None:
+    async def _handoff(self, ctx: AppContext, crm_conv_id: str) -> None:
         try:
-            await self._ctx.crm.post_handoff(crm_conv_id, "error")
+            await ctx.crm.post_handoff(crm_conv_id, "error")
         except CrmError as exc:
             logger.error("sender: no pude registrar el handoff tras abandono: %s", exc)

--- a/app/state.py
+++ b/app/state.py
@@ -28,6 +28,14 @@ class Conversation:
     id: int
     wa_identity: str
     crm_conversation_id: str | None = None
+    # De quién es esta conversación. Cadena vacía = instalación de un solo
+    # negocio, que es lo que era todo antes del modo multi-organización.
+    #
+    # Importa más de lo que parece: la identidad SOLA dejó de identificar una
+    # conversación en cuanto una Nea atiende a varios negocios, porque la
+    # misma persona puede escribirle a dos.
+    organization_id: str = ""
+    organization_slug: str = ""
     phase: str = "descubrimiento"  # descubrimiento|insight|salida|agendando|cerrada
     greeted: bool = False
     media_notice_sent: bool = False
@@ -84,6 +92,11 @@ class PendingSend:
     next_retry_at: datetime
     delivered_at: datetime | None = None
     abandoned_at: datetime | None = None
+    # Para que el reintento diferido sepa con qué credencial hablarle al CRM
+    # cuando despierte. Van al final por la regla de los dataclass: un campo
+    # con valor por defecto no puede preceder a uno sin él.
+    organization_id: str = ""
+    organization_slug: str = ""
 
 
 @dataclass
@@ -127,7 +140,12 @@ class Store(Protocol):
     ) -> None: ...
 
     # conversaciones
-    async def get_or_create_conversation(self, wa_identity: str) -> Conversation: ...
+    async def get_or_create_conversation(
+        self,
+        wa_identity: str,
+        organization_id: str = "",
+        organization_slug: str = "",
+    ) -> Conversation: ...
     async def update_conversation(self, conversation_id: int, **fields: Any) -> None: ...
     async def reset_conversation(self, conversation_id: int) -> None:
         """Borra historial + slots y regresa la conversación a estado inicial
@@ -155,7 +173,12 @@ class Store(Protocol):
 
     # cola de envíos pendientes (respuestas que no pudieron salir en el turno)
     async def enqueue_pending_send(
-        self, conversation_id: int, crm_conversation_id: str, content: str
+        self,
+        conversation_id: int,
+        crm_conversation_id: str,
+        content: str,
+        organization_id: str = "",
+        organization_slug: str = "",
     ) -> int: ...
     async def due_pending_sends(self, now: datetime) -> list[PendingSend]: ...
     async def mark_pending_send_delivered(self, pending_id: int) -> None: ...
@@ -185,7 +208,7 @@ class MemoryStore:
         self.processed: set[str] = set()
         self.relays: dict[int, RelayItem] = {}
         self.conversations: dict[int, Conversation] = {}
-        self._conv_by_identity: dict[str, int] = {}
+        self._conv_by_identity: dict[tuple[str, str], int] = {}
         self.messages: list[BotMessage] = []
         self.offered: dict[int, list[OfferedSlot]] = {}
         self.pending_sends: dict[int, PendingSend] = {}
@@ -225,14 +248,25 @@ class MemoryStore:
         item.attempts = attempts
         item.next_retry_at = next_retry_at
 
-    async def get_or_create_conversation(self, wa_identity: str) -> Conversation:
-        cid = self._conv_by_identity.get(wa_identity)
+    async def get_or_create_conversation(
+        self,
+        wa_identity: str,
+        organization_id: str = "",
+        organization_slug: str = "",
+    ) -> Conversation:
+        clave = (organization_id, wa_identity)
+        cid = self._conv_by_identity.get(clave)
         if cid is not None:
             return self.conversations[cid]
         cid = next(self._ids)
-        conv = Conversation(id=cid, wa_identity=wa_identity)
+        conv = Conversation(
+            id=cid,
+            wa_identity=wa_identity,
+            organization_id=organization_id,
+            organization_slug=organization_slug,
+        )
         self.conversations[cid] = conv
-        self._conv_by_identity[wa_identity] = cid
+        self._conv_by_identity[clave] = cid
         return conv
 
     async def update_conversation(self, conversation_id: int, **fields: Any) -> None:
@@ -288,7 +322,12 @@ class MemoryStore:
         self.offered.pop(conversation_id, None)
 
     async def enqueue_pending_send(
-        self, conversation_id: int, crm_conversation_id: str, content: str
+        self,
+        conversation_id: int,
+        crm_conversation_id: str,
+        content: str,
+        organization_id: str = "",
+        organization_slug: str = "",
     ) -> int:
         pid = next(self._ids)
         now = utcnow()
@@ -296,6 +335,8 @@ class MemoryStore:
             id=pid, conversation_id=conversation_id,
             crm_conversation_id=crm_conversation_id, content=content,
             attempts=0, created_at=now, next_retry_at=now,
+            organization_id=organization_id,
+            organization_slug=organization_slug,
         )
         return pid
 
@@ -354,6 +395,13 @@ class AppContext:
     crm: Any  # CrmClient
     llm: Any  # OpenAiLlm o fake con .complete()
     profile: Any | None = None  # ProfileProvider; None en tests = perfil mínimo
+    # Modo multi-organización: el registro de clientes por organización.
+    # None fuera de ese modo — una Nea de un solo negocio no lo necesita, y
+    # que sea None es lo que hace evidente en qué modo está corriendo.
+    registro: Any | None = None  # RegistroDeOrganizaciones
+    # (organization_id, slug) del turno en curso. La pone el despacho al armar
+    # el contexto del turno; None fuera del modo multi-organización.
+    organizacion: tuple[str, str] | None = None
     coalescer: Any | None = None
     relay_wake: asyncio.Event = field(default_factory=asyncio.Event)
     # ¿El CRM de esta instancia tiene motor de agenda? Vocero lo trae detrás de

--- a/app/turn.py
+++ b/app/turn.py
@@ -107,7 +107,12 @@ async def run_turn(
         )
         return
 
-    conv = await ctx.store.get_or_create_conversation(identity)
+    # La conversación es de una ORGANIZACIÓN, no solo de una identidad. Con
+    # una Nea de un solo negocio la tupla es vacía y todo queda igual que
+    # siempre; con varias, es lo que impide que el mismo teléfono escribiendo
+    # a dos negocios comparta historial. Ver migrations/004_multiorg.sql.
+    org_id, org_slug = ctx.organizacion or ("", "")
+    conv = await ctx.store.get_or_create_conversation(identity, org_id, org_slug)
 
     # --- Comando /reset (líneas de prueba) --------------------------------
     # Corre ANTES de los gates de aiEnabled/ventana: un reset también debe
@@ -393,7 +398,13 @@ async def _send(ctx: AppContext, conv_id: int, crm_conv_id: str, text: str) -> b
             logger.warning("envío falló (intento %d): %s", attempt + 1, exc)
             if attempt < SEND_ATTEMPTS - 1:
                 await asyncio.sleep(2.0**attempt)
-    pending_id = await ctx.store.enqueue_pending_send(conv_id, crm_conv_id, text)
+    # La organización viaja con el encolado: cuando el SenderWorker despierte
+    # —quizá horas después— tiene que hablarle al CRM con la credencial de
+    # ESTA, y para entonces el turno ya no existe.
+    org_id, org_slug = ctx.organizacion or ("", "")
+    pending_id = await ctx.store.enqueue_pending_send(
+        conv_id, crm_conv_id, text, org_id, org_slug
+    )
     logger.error(
         "envío agotó reintentos del turno — encolado como pending_send %d",
         pending_id,

--- a/migrations/004_multiorg.sql
+++ b/migrations/004_multiorg.sql
@@ -1,0 +1,44 @@
+-- Multi-organización: una Nea atendiendo a varios negocios.
+--
+-- ## El fallo que esta migración cierra
+--
+-- `wa_identity` era UNIQUE a secas. Con un solo negocio eso es correcto: una
+-- identidad de WhatsApp es una persona, y una persona es una conversación.
+--
+-- Con varios negocios en la misma Nea deja de serlo. Dos miembros pueden tener
+-- al MISMO cliente —la misma persona escribiéndole a dos negocios distintos, o
+-- sencillamente dos leads con números que coinciden tras canonicalizar— y con
+-- la unicidad global las dos conversaciones se fusionaban en una: el historial
+-- de un negocio entraba en el prompt del otro.
+--
+-- La clave pasa a ser (organización, identidad). Cadena vacía = "sin
+-- organización", que es exactamente lo que era antes, así que una instalación
+-- de un solo negocio no cambia de comportamiento.
+--
+-- ## Por qué '' y no NULL
+--
+-- En Postgres los NULL son distintos entre sí dentro de un índice único, así
+-- que UNIQUE(organization_id, wa_identity) con organization_id NULL permitiría
+-- duplicados justo en la instalación de siempre — el caso que no debía cambiar.
+
+ALTER TABLE bot_conversation
+  ADD COLUMN IF NOT EXISTS organization_id TEXT NOT NULL DEFAULT '';
+ALTER TABLE bot_conversation
+  ADD COLUMN IF NOT EXISTS organization_slug TEXT NOT NULL DEFAULT '';
+
+-- El nombre lo pone Postgres al declarar UNIQUE en la columna (001_init).
+ALTER TABLE bot_conversation
+  DROP CONSTRAINT IF EXISTS bot_conversation_wa_identity_key;
+
+CREATE UNIQUE INDEX IF NOT EXISTS uq_bot_conversation_org_identity
+  ON bot_conversation (organization_id, wa_identity);
+
+-- El envío diferido también necesita saber de quién es: cuando el worker
+-- despierte, tiene que hablarle al CRM con la credencial de ESA organización.
+-- Sin esto, un envío que falló en un multi-organización no se podría reintentar
+-- nunca, y la garantía de "jamás se descarta" (incidente 2026-08-03) quedaría
+-- rota en silencio, que es la peor forma de romperla.
+ALTER TABLE pending_send
+  ADD COLUMN IF NOT EXISTS organization_id TEXT NOT NULL DEFAULT '';
+ALTER TABLE pending_send
+  ADD COLUMN IF NOT EXISTS organization_slug TEXT NOT NULL DEFAULT '';

--- a/tests/test_multiorg.py
+++ b/tests/test_multiorg.py
@@ -1,0 +1,241 @@
+"""Modo multi-organización: una Nea atendiendo a varios negocios.
+
+Lo que se prueba aquí, en orden de importancia:
+
+1. **La credencial derivada coincide con la del CRM.** Es un contrato entre dos
+   repositorios; si se desvía un byte, Nea recibe 401 en todo y el síntoma es
+   "no contesta", que no apunta a nada.
+2. **Dos negocios no comparten conversación.** Aunque les escriba el mismo
+   teléfono. Era el fallo que traía la unicidad global de `wa_identity`.
+3. **Sin llave del miembro no hay turno.** Caer a la del entorno le cobraría a
+   la cuenta del dueño de la plataforma el consumo de todos.
+"""
+from __future__ import annotations
+
+import base64
+import hashlib
+import hmac
+
+import pytest
+
+from app.config import Settings
+from app.multiorg import (
+    CrmSinOrganizacion,
+    RegistroDeOrganizaciones,
+    credencial_derivada,
+    ctx_de_organizacion,
+    organizacion_del_despacho,
+)
+from app.state import AppContext, MemoryStore
+
+SECRETO = "un-secreto-de-despliegue-largo-y-aburrido"
+ORG = "org_abc123"
+
+
+# ------------------------------------------------------ la credencial ------
+
+
+def test_credencial_es_hmac_base64url_sin_relleno():
+    """Réplica independiente del cálculo, para que no se pruebe consigo mismo."""
+    esperado = base64.urlsafe_b64encode(
+        hmac.new(
+            SECRETO.encode(),
+            f"vocero:cerebro:v1:{ORG}".encode(),
+            hashlib.sha256,
+        ).digest()
+    ).rstrip(b"=").decode()
+    assert credencial_derivada(SECRETO, ORG) == esperado
+
+
+def test_credencial_coincide_con_la_del_crm():
+    """El valor que produce Node para estas mismas entradas.
+
+    Fijado a mano y no calculado: si alguien cambia el dominio de separación o
+    la codificación, esta prueba se pone roja aquí en vez de en producción con
+    un 401 mudo. El valor sale de:
+
+        createHmac("sha256", SECRETO)
+          .update("vocero:cerebro:v1:org_abc123")
+          .digest("base64url")
+    """
+    assert credencial_derivada(SECRETO, ORG) == (
+        "_BqRKryMUdexcuLj_3RG1ARbgqr_LhXRSLJYmrw5VJ0"
+    )
+
+
+def test_credencial_distinta_por_organizacion():
+    a = credencial_derivada(SECRETO, "org_a")
+    b = credencial_derivada(SECRETO, "org_b")
+    assert a != b
+
+
+def test_credencial_distinta_al_rotar_el_secreto():
+    """Rotar el secreto tiene que revocar: si no cambiara, no revocaría nada."""
+    assert credencial_derivada(SECRETO, ORG) != credencial_derivada("otro", ORG)
+
+
+def test_sin_relleno():
+    """43 caracteres, sin '='. Node no lo pone y el CRM compara literal."""
+    cred = credencial_derivada(SECRETO, ORG)
+    assert "=" not in cred
+    assert len(cred) == 43
+
+
+# ------------------------------------------------- la organización ---------
+
+
+def test_organizacion_del_despacho():
+    payload = {"organization": {"id": "org_1", "slug": "mi-negocio"}}
+    assert organizacion_del_despacho(payload) == ("org_1", "mi-negocio")
+
+
+def test_organizacion_sin_slug_usa_el_id():
+    """El slug puede faltar; el id no. Es lo que acepta el CRM en la cabecera."""
+    assert organizacion_del_despacho({"organization": {"id": "org_1"}}) == (
+        "org_1",
+        "org_1",
+    )
+
+
+@pytest.mark.parametrize(
+    "payload",
+    [{}, {"organization": {}}, {"organization": {"slug": "sin-id"}}],
+)
+def test_sin_id_no_hay_organizacion(payload):
+    """Sin id no hay credencial que derivar, así que no hay a quién contestar."""
+    assert organizacion_del_despacho(payload) is None
+
+
+# ------------------------------------------------------- el registro -------
+
+
+def test_el_registro_reutiliza_el_cliente_por_organizacion():
+    reg = RegistroDeOrganizaciones("http://crm", SECRETO)
+    uno = reg.cliente("org_1", "uno")
+    otra_vez = reg.cliente("org_1", "uno")
+    distinto = reg.cliente("org_2", "dos")
+    assert uno is otra_vez
+    assert uno is not distinto
+
+
+def test_el_registro_cachea_el_llm_por_credencial():
+    """Cachear por credencial y no por organización: rotar la llave debe surtir
+    efecto en el turno siguiente, sin invalidar nada a mano."""
+    reg = RegistroDeOrganizaciones("http://crm", SECRETO)
+    ajustes = Settings(llm_model="modelo/base", llm_transcribe_model="oye/algo")
+    base = {"apiKey": "sk-1", "model": "a/b", "baseUrl": "http://x/v1"}
+
+    primero = reg.llm(base, ajustes)
+    assert reg.llm(dict(base), ajustes) is primero
+
+    rotada = {**base, "apiKey": "sk-2"}
+    assert reg.llm(rotada, ajustes) is not primero
+
+
+def test_el_llm_rellena_huecos_con_los_ajustes_menos_la_llave():
+    """Sin modelo elegido se usa el de la instancia. Sin llave NO se rellena:
+    pensar con la del dueño de la plataforma es el gasto que esto evita."""
+    reg = RegistroDeOrganizaciones("http://crm", SECRETO)
+    ajustes = Settings(
+        llm_api_key="sk-del-dueño",
+        llm_model="modelo/instancia",
+        llm_transcribe_model="oye/instancia",
+    )
+    cliente = reg.llm({"apiKey": "sk-del-miembro"}, ajustes)
+    assert cliente._model == "modelo/instancia"
+    assert cliente._transcribe_model == "oye/instancia"
+    # La llave es la del miembro, jamás la del entorno.
+    assert cliente._client.api_key == "sk-del-miembro"
+
+
+# --------------------------------------------------- el centinela ----------
+
+
+@pytest.mark.asyncio
+async def test_el_centinela_revienta_al_escribir():
+    """Un camino que se olvide de armar el cliente tiene que fallar aquí y no
+    escribirle en silencio al negocio equivocado."""
+    crm = CrmSinOrganizacion()
+    with pytest.raises(RuntimeError, match="sin saber de qué organización"):
+        crm.send_message
+
+
+@pytest.mark.asyncio
+async def test_el_centinela_deja_arrancar_y_apagar():
+    """Las dos que usa el ciclo de vida, y ninguna escribe nada."""
+    crm = CrmSinOrganizacion()
+    assert await crm.agenda_available() is True
+    assert await crm.aclose() is None
+
+
+# ------------------------------------------- el contexto de los workers ----
+
+
+def _ctx(multi: bool) -> AppContext:
+    settings = Settings(
+        vocero_mode="cloud" if multi else "",
+        crm_organization="" if multi else "unica",
+        crm_brain_secret=SECRETO,
+    )
+    return AppContext(
+        settings=settings,
+        store=MemoryStore(),
+        crm=CrmSinOrganizacion() if multi else object(),
+        llm=object(),
+        registro=RegistroDeOrganizaciones("http://crm", SECRETO) if multi else None,
+    )
+
+
+def test_fuera_de_multiorg_el_contexto_no_cambia():
+    ctx = _ctx(multi=False)
+    assert ctx_de_organizacion(ctx, "", "") is ctx
+
+
+def test_en_multiorg_el_contexto_trae_el_cliente_de_esa_organizacion():
+    ctx = _ctx(multi=True)
+    resuelto = ctx_de_organizacion(ctx, "org_1", "uno")
+    assert resuelto is not None
+    assert resuelto.organizacion == ("org_1", "uno")
+    assert resuelto.crm is ctx.registro.cliente("org_1", "uno")
+
+
+def test_sin_organizacion_conocida_el_worker_se_calla():
+    """Una fila vieja, escrita antes de esta versión. Contestar con la
+    credencial equivocada sería escribirle a otro negocio."""
+    ctx = _ctx(multi=True)
+    assert ctx_de_organizacion(ctx, "", "") is None
+
+
+# --------------------------------------- aislamiento de conversaciones -----
+
+
+@pytest.mark.asyncio
+async def test_el_mismo_telefono_en_dos_negocios_no_comparte_conversacion():
+    """EL fallo que traía la unicidad global de wa_identity.
+
+    La misma persona puede escribirle a dos negocios distintos. Con una sola
+    conversación, el historial de uno entraba en el prompt del otro.
+    """
+    store = MemoryStore()
+    telefono = "5215512345678"
+
+    de_a = await store.get_or_create_conversation(telefono, "org_a", "a")
+    de_b = await store.get_or_create_conversation(telefono, "org_b", "b")
+
+    assert de_a.id != de_b.id
+    assert de_a.organization_id == "org_a"
+    assert de_b.organization_id == "org_b"
+
+    # Y el historial no se cruza.
+    await store.add_message(de_a.id, "user", "hola, soy cliente de A")
+    de_b_otra_vez = await store.get_or_create_conversation(telefono, "org_b", "b")
+    assert await store.recent_messages(de_b_otra_vez.id, 10) == []
+
+
+@pytest.mark.asyncio
+async def test_sin_organizacion_se_comporta_como_siempre():
+    """Una Nea de un solo negocio: la misma identidad, la misma conversación."""
+    store = MemoryStore()
+    una = await store.get_or_create_conversation("5215512345678")
+    otra = await store.get_or_create_conversation("5215512345678")
+    assert una.id == otra.id

--- a/tests/test_multiorg.py
+++ b/tests/test_multiorg.py
@@ -118,35 +118,84 @@ def test_el_registro_reutiliza_el_cliente_por_organizacion():
     assert uno is not distinto
 
 
-def test_el_registro_cachea_el_llm_por_credencial():
-    """Cachear por credencial y no por organización: rotar la llave debe surtir
-    efecto en el turno siguiente, sin invalidar nada a mano."""
+def test_el_llm_apunta_al_crm_y_no_al_proveedor():
+    """La llave del miembro NO viaja: piensa el CRM y Nea le pide.
+
+    Es la propiedad de la que cuelga todo el diseño. Si esto se rompiera y el
+    cliente volviera a apuntar a OpenRouter, haría falta una llave de verdad —
+    y la única a mano sería la del entorno, o sea la del dueño de la
+    plataforma pagando por todos.
+    """
     reg = RegistroDeOrganizaciones("http://crm", SECRETO)
-    ajustes = Settings(llm_model="modelo/base", llm_transcribe_model="oye/algo")
-    base = {"apiKey": "sk-1", "model": "a/b", "baseUrl": "http://x/v1"}
-
-    primero = reg.llm(base, ajustes)
-    assert reg.llm(dict(base), ajustes) is primero
-
-    rotada = {**base, "apiKey": "sk-2"}
-    assert reg.llm(rotada, ajustes) is not primero
-
-
-def test_el_llm_rellena_huecos_con_los_ajustes_menos_la_llave():
-    """Sin modelo elegido se usa el de la instancia. Sin llave NO se rellena:
-    pensar con la del dueño de la plataforma es el gasto que esto evita."""
-    reg = RegistroDeOrganizaciones("http://crm", SECRETO)
-    ajustes = Settings(
-        llm_api_key="sk-del-dueño",
-        llm_model="modelo/instancia",
-        llm_transcribe_model="oye/instancia",
+    ajustes = Settings(llm_api_key="sk-del-dueño", llm_model="modelo/instancia")
+    cliente = reg.llm(
+        ORG, "mi-negocio", {"path": "/api/brains/llm", "model": "a/b"}, ajustes
     )
-    cliente = reg.llm({"apiKey": "sk-del-miembro"}, ajustes)
-    assert cliente._model == "modelo/instancia"
-    assert cliente._transcribe_model == "oye/instancia"
-    # La llave es la del miembro, jamás la del entorno.
-    assert cliente._client.api_key == "sk-del-miembro"
 
+    assert str(cliente._client.base_url).startswith("http://crm/api/brains/llm")
+    # La credencial derivada, no una llave de OpenRouter.
+    assert cliente._client.api_key == credencial_derivada(SECRETO, ORG)
+    assert "sk-del-dueño" not in str(cliente._client.api_key)
+
+
+def test_el_llm_dice_de_que_organizacion_es_cada_llamada():
+    """El CRM lo necesita para autenticar: sin la cabecera son todas 401."""
+    reg = RegistroDeOrganizaciones("http://crm", SECRETO)
+    cliente = reg.llm(ORG, "mi-negocio", {"model": "a/b"}, Settings())
+    cabeceras = cliente._client.default_headers or {}
+    assert cabeceras.get("X-Vocero-Organization") == "mi-negocio"
+
+
+def test_el_modelo_que_conversa_cae_al_de_la_instancia():
+    """Un miembro que no eligió modelo tiene que poder conversar igual."""
+    reg = RegistroDeOrganizaciones("http://crm", SECRETO)
+    ajustes = Settings(llm_model="modelo/instancia")
+    cliente = reg.llm(ORG, "mi-negocio", {}, ajustes)
+    assert cliente._model == "modelo/instancia"
+
+
+def test_el_modelo_que_escucha_NO_cae_a_ninguno():
+    """Sin modelo que oiga, no se transcribe. Y se dice.
+
+    Caer al que conversa mandaría el audio a un modelo que no oye, y lo que
+    volviera parecería una transcripción sin serlo. Quien la lea no tiene cómo
+    saber que es inventada — es peor que decir que no se pudo.
+    """
+    reg = RegistroDeOrganizaciones("http://crm", SECRETO)
+    ajustes = Settings(llm_transcribe_model="oye/instancia")
+    cliente = reg.llm(ORG, "mi-negocio", {"model": "a/b"}, ajustes)
+    assert cliente._transcribe_model == ""
+
+
+@pytest.mark.asyncio
+async def test_sin_modelo_que_oiga_transcribir_falla_sin_llamar_a_nadie():
+    """El guardarraíl del caso anterior, en el sitio donde muerde."""
+    from app.llm import LlmExhausted, OpenAiLlm
+
+    cliente = OpenAiLlm("cred", "a/b", transcribe_model="", base_url="http://crm")
+    with pytest.raises(LlmExhausted, match="sin modelo de transcripción"):
+        await cliente.transcribe(b"...", "audio/ogg")
+
+
+def test_el_registro_cachea_el_llm_pero_no_entre_organizaciones():
+    """Reutilizar el cliente ahorra sockets; compartirlo entre negocios
+    los mezclaría, porque cada uno lleva su credencial y su cabecera.
+    """
+    reg = RegistroDeOrganizaciones("http://crm", SECRETO)
+    config = {"model": "a/b"}
+    uno = reg.llm("org_1", "uno", dict(config), Settings())
+    otra_vez = reg.llm("org_1", "uno", dict(config), Settings())
+    de_otro = reg.llm("org_2", "dos", dict(config), Settings())
+    assert uno is otra_vez
+    assert uno is not de_otro
+
+
+def test_cambiar_de_modelo_surte_efecto_en_el_turno_siguiente():
+    """Sin invalidar nada a mano: la tupla de caché cambia con el modelo."""
+    reg = RegistroDeOrganizaciones("http://crm", SECRETO)
+    antes = reg.llm(ORG, "n", {"model": "a/b"}, Settings())
+    despues = reg.llm(ORG, "n", {"model": "c/d"}, Settings())
+    assert antes is not despues
 
 # --------------------------------------------------- el centinela ----------
 


### PR DESCRIPTION
## Por qué

En modo cloud, Nea atendía a **una** organización: `CRM_BRAIN_SECRET`, `CRM_ORGANIZATION` y `LLM_API_KEY` son valores únicos. Servir a diez negocios significaba levantar diez Neas.

**Sin la bandera no cambia nada.** Una instalación existente se comporta igual: los parámetros de organización tienen valor por defecto vacío en todo el store, y las 191 pruebas lo fijan.

## Qué hace

Con `VOCERO_MODE=cloud` y **`CRM_ORGANIZATION` vacía**, esta Nea sirve a todos los negocios que el CRM le suscriba.

El secreto pasa a ser el del **despliegue** que registró el CRM —uno solo, así que todos los despachos se verifican con él— y de ese secreto se **deriva** la credencial de cada negocio:

```
HMAC-SHA256(secreto, "vocero:cerebro:v1:{organizationId}")
```

Nea la calcula desde el `organization.id` que viene en el despacho. El CRM no se la manda, y una credencial que no viaja no se filtra. Como no se guarda ni caduca, un worker de seguimiento que despierta cuatro horas después la recalcula igual.

## Con qué piensa: no con una llave, sino pidiéndoselo al CRM

**La llave de OpenRouter del miembro no llega hasta aquí.** El cliente del modelo apunta a `{CRM}/api/brains/llm` con la credencial derivada de esa organización, y el CRM le pone la credencial real al reenviar al proveedor.

Para el SDK de OpenAI es un proveedor compatible más, así que el cambio cabe en el registro de organizaciones y el turno no se entera.

Es a propósito, y por dos razones: una llave filtrada no se puede desfiltrar, y cuando el proveedor la rechaza conviene que el 401 lo reciba el CRM, que es quien puede avisarle a su dueño. Con la llave viajando, ese código se lo comía Nea y el miembro veía «activa» mientras nada funcionaba.

Si el CRM no ofrece pensar —este despliegue no es de confianza, o el miembro no tiene token activo— Nea se calla y deja la conversación a un humano. Caer a `LLM_API_KEY` del entorno le cobraría al dueño de la plataforma el consumo de todos.

## Un fallo que apareció por el camino

No era del modo nuevo sino del esquema: **`wa_identity` era `UNIQUE` global**.

Con dos negocios en el mismo proceso, la misma persona escribiéndoles a los dos **compartía conversación**, y el historial de uno entraba en el prompt del otro. La clave pasa a ser `(organización, identidad)`.

Se usa cadena vacía y no `NULL` porque en Postgres los `NULL` son distintos entre sí dentro de un índice único: con `NULL`, el caso que **no** debía cambiar —la instalación de un solo negocio— habría sido justo el que se rompía.

## Y otro, más pequeño

**Sin modelo que oiga, no se transcribe.** Antes se caía al modelo que conversa; eso devuelve una alucinación con pinta de transcripción, y quien la lee no tiene cómo saber que es falsa. Ahora `transcribe` lanza `LlmExhausted` antes de llamar a nadie, y el turno degrada por el camino honesto que ya existía («no pude abrir eso»).

## El centinela

`ctx.crm` y `ctx.llm` se arman **por turno**. El del arranque es un centinela que revienta al usarse: si fuera un cliente de verdad —el de la primera organización, digamos—, un camino que se olvidara de cambiarlo escribiría en la bandeja equivocada y nadie se enteraría. Con esto, ese olvido falla en el sitio exacto.

## Cómo se probó

- **29 pruebas nuevas** (191 en total, todas verdes).
- Una fija el **mismo valor de credencial** que su gemela en `vocerocrm-cloud`: es un contrato entre repositorios y desviarse un byte da 401 mudo en todo.
- Las del modelo fijan lo que importa: el cliente apunta al CRM y **no** al proveedor, la credencial es la derivada y **no** una llave de OpenRouter, el modelo que conversa cae al de la instancia y el que escucha **no** cae a ninguno.
- **Mutación verificada**: devolver la unicidad global de `wa_identity` pone rojo el aislamiento de conversaciones.

> Va junto con kevinrivm/vocerocrm-cloud#18.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
