### PR TITLE
fix: en multi-organización el arranque no construye un modelo

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -112,12 +112,13 @@ class Settings(BaseSettings):
     # mensaje y se lo DESPACHA a Nea firmado, y Nea contesta por
     # `/api/brains/*`. Su personalidad y su conocimiento vienen de SU CRM.
     #
-    # **Una instancia atiende a UNA organización.** `crm_brain_secret`,
-    # `crm_organization` y `llm_api_key` son valores únicos: un despacho de
-    # otra organización vendría firmado con otro secreto y se rechazaría con
-    # 401. Falla cerrado —no mezcla conversaciones ajenas ni le carga el token
-    # de un negocio a otro—, pero atender a varios negocios hoy significa una
-    # instancia por negocio.
+    # Con `crm_organization` puesta atiende a ESE negocio y a nadie más: un
+    # despacho de otra organización viene firmado con otro secreto y se
+    # rechaza con 401.
+    #
+    # Con `crm_organization` vacía atiende a todos los que el CRM le suscriba
+    # (ver `multi_org` más abajo). Entonces `llm_api_key` no se usa: la llave
+    # es de cada miembro y la pone el CRM, no viaja hasta aquí.
     vocero_mode: str = ""
 
     # Secreto del cerebro, el que genera el CRM en Ajustes → Cerebro. Firma lo

--- a/app/main.py
+++ b/app/main.py
@@ -25,7 +25,11 @@ from app.dispatch import router as dispatch_router
 from app.db import PgStore
 from app.followup import FollowupWorker
 from app.llm import OpenAiLlm
-from app.multiorg import CrmSinOrganizacion, RegistroDeOrganizaciones
+from app.multiorg import (
+    CrmSinOrganizacion,
+    LlmSinOrganizacion,
+    RegistroDeOrganizaciones,
+)
 from app.profile import ProfileProvider
 from app.relay import RelayWorker
 from app.sender import SenderWorker
@@ -88,11 +92,20 @@ def create_app(ctx: AppContext | None = None) -> FastAPI:
                 settings=settings,
                 store=store,
                 crm=crm,
-                llm=OpenAiLlm(
-                    settings.llm_api_key,
-                    settings.llm_model,
-                    transcribe_model=settings.llm_transcribe_model,
-                    base_url=settings.llm_base_url or None,
+                # Mismo criterio que el CRM de arriba: en multi-organización
+                # no hay modelo por defecto. Además de que no habría con qué
+                # construirlo —Nea no lleva la llave de nadie—, uno de verdad
+                # aquí le cobraría al dueño de la plataforma el consumo de sus
+                # miembros si algún camino se olvidara de cambiarlo.
+                llm=(
+                    LlmSinOrganizacion()
+                    if settings.multi_org
+                    else OpenAiLlm(
+                        settings.llm_api_key,
+                        settings.llm_model,
+                        transcribe_model=settings.llm_transcribe_model,
+                        base_url=settings.llm_base_url or None,
+                    )
                 ),
                 # En multi-organización el perfil es de cada negocio y lo
                 # sirve el registro; un proveedor global aquí serviría el

--- a/app/multiorg.py
+++ b/app/multiorg.py
@@ -227,6 +227,38 @@ class CrmSinOrganizacion:
             f"despacho, no el arranque"
         )
 
+
+class LlmSinOrganizacion:
+    """El "cliente" del modelo mientras no se sabe de qué organización.
+
+    Hermano de `CrmSinOrganizacion`, y por el mismo motivo. En modo
+    multi-organización no hay un modelo por defecto: cada turno arma el suyo
+    apuntando al CRM con la credencial derivada de SU organización, y es el
+    CRM quien pone la llave del miembro al reenviar.
+
+    Antes aquí se construía un `OpenAiLlm` con `LLM_API_KEY` del entorno. Tenía
+    dos fallos, y el segundo es peor que el primero:
+
+    1. **No arranca.** En este modo esa variable no existe a propósito —Nea no
+       lleva la llave de nadie—, y el SDK de OpenAI se niega a construirse sin
+       credencial. El proceso moría en el `lifespan`.
+    2. **Si existiera, cobraría al que no era.** Un camino que se olvidara de
+       cambiar el cliente pensaría con la llave del dueño de la plataforma, y
+       el consumo de un miembro se lo pagaría otro. En silencio.
+
+    Por eso revienta en vez de degradar: `LlmExhausted` haría que el turno
+    siguiera su camino de «no pude pensar», y un olvido de cableado se leería
+    como un fallo del proveedor.
+    """
+
+    def __getattr__(self, nombre: str) -> Any:
+        raise RuntimeError(
+            f"se intentó usar el modelo ({nombre}) sin saber de qué "
+            f"organización es este turno: en modo multi-organización quien "
+            f"piensa es el CRM con la credencial del miembro, y ese cliente lo "
+            f"arma el despacho, no el arranque"
+        )
+
 def ctx_de_organizacion(
     ctx: "AppContext",
     organization_id: str,

--- a/tests/test_multiorg.py
+++ b/tests/test_multiorg.py
@@ -12,15 +12,18 @@ Lo que se prueba aquí, en orden de importancia:
 """
 from __future__ import annotations
 
+import asyncio
 import base64
 import hashlib
 import hmac
 
 import pytest
 
+from app import main
 from app.config import Settings
 from app.multiorg import (
     CrmSinOrganizacion,
+    LlmSinOrganizacion,
     RegistroDeOrganizaciones,
     credencial_derivada,
     ctx_de_organizacion,
@@ -288,3 +291,84 @@ async def test_sin_organizacion_se_comporta_como_siempre():
     una = await store.get_or_create_conversation("5215512345678")
     otra = await store.get_or_create_conversation("5215512345678")
     assert una.id == otra.id
+
+
+# ── El arranque ───────────────────────────────────────────────────────────
+#
+# Todo lo demás en esta suite construye el `AppContext` a mano. El arranque de
+# verdad —el que arma sus propios recursos— no lo cubría nadie, y ahí es donde
+# esto se rompió en producción: el proceso moría en el `lifespan` porque
+# intentaba construir un cliente del modelo sin llave. Y en este modo NO hay
+# llave a propósito.
+
+
+class _StoreDePrueba:
+    """Lo justo que el arranque le pide a la base."""
+
+    async def connect(self) -> None:
+        return None
+
+    async def migrate(self, _directorio) -> None:
+        return None
+
+    async def aclose(self) -> None:
+        return None
+
+
+class _WorkerQuieto:
+    """Un worker que no hace nada: aquí se prueba el arranque, no el trabajo."""
+
+    def __init__(self, *_args, **_kwargs) -> None:
+        pass
+
+    async def run(self) -> None:
+        await asyncio.Event().wait()
+
+    async def aclose(self) -> None:
+        return None
+
+
+@pytest.fixture
+def arranque_multiorg(monkeypatch):
+    """Producción tal cual: cloud, sin organización fija y sin llave de nadie."""
+    monkeypatch.setenv("VOCERO_MODE", "cloud")
+    monkeypatch.setenv("CRM_BASE_URL", "http://vocero-cloud:3000")
+    monkeypatch.setenv("CRM_BRAIN_SECRET", "secreto-del-despliegue-de-32-caracteres")
+    monkeypatch.setenv("DATABASE_URL", "postgres://no-se-usa")
+    # Vacías, no borradas: una variable borrada en Coolify llega aquí como el
+    # default (""), y un `.env` en el repo no debe poder salvar esta prueba
+    # dándole una llave que producción no tiene.
+    for ausente in ("CRM_ORGANIZATION", "LLM_API_KEY", "OPENAI_API_KEY"):
+        monkeypatch.setenv(ausente, "")
+    monkeypatch.setattr(main, "PgStore", lambda *_a, **_k: _StoreDePrueba())
+    monkeypatch.setattr(main, "RelayWorker", _WorkerQuieto)
+    monkeypatch.setattr(main, "FollowupWorker", _WorkerQuieto)
+    monkeypatch.setattr(main, "SenderWorker", _WorkerQuieto)
+
+
+async def test_el_arranque_multiorg_no_muere_sin_llave(arranque_multiorg):
+    """El fallo exacto que tiró el despliegue.
+
+    Sin este arreglo, el SDK de OpenAI se niega a construirse sin credencial
+    ("Missing credentials") y el proceso sale en el `lifespan`: contenedor
+    unhealthy, rollback, y Nea nunca arriba.
+    """
+    app = main.create_app()
+    async with app.router.lifespan_context(app):
+        ctx = app.state.ctx
+        assert ctx.settings.multi_org
+        assert isinstance(ctx.llm, LlmSinOrganizacion)
+
+
+async def test_el_modelo_del_arranque_revienta_al_usarse(arranque_multiorg):
+    """No degrada: revienta.
+
+    `LlmExhausted` haría que el turno siguiera su camino de "no pude pensar" y
+    un olvido de cableado se leería como un fallo del proveedor. Además, un
+    cliente de verdad aquí le cobraría al dueño de la plataforma el consumo de
+    sus miembros.
+    """
+    app = main.create_app()
+    async with app.router.lifespan_context(app):
+        with pytest.raises(RuntimeError, match="sin saber de qué organización"):
+            await app.state.ctx.llm.complete([{"role": "user", "content": "hola"}])


### PR DESCRIPTION
## El síntoma

El primer despliegue de Nea en cloud multi-organización no arrancó. Contenedor unhealthy, rollback, y en el log:

```
File "/app/app/main.py", line 91, in lifespan
    llm=OpenAiLlm(
openai.OpenAIError: Missing credentials. Please pass an `api_key`...
```

## La causa

El `lifespan` construye el contexto de arranque. Para el CRM ya distinguía el modo —en multi-organización pone `CrmSinOrganizacion`, un centinela, porque no hay cliente por defecto— pero para el modelo seguía construyendo un `OpenAiLlm` con `LLM_API_KEY` del entorno.

En este modo esa variable **no existe a propósito**: Nea no lleva la llave de nadie, piensa el CRM con la credencial del miembro. El SDK de OpenAI se niega a construirse sin credencial, y el proceso sale antes de servir nada.

## El arreglo

`LlmSinOrganizacion`, hermano del centinela que ya existía y por el mismo motivo.

Y el motivo de fondo es peor que no arrancar: si esa variable **sí** estuviera puesta, un camino que se olvidara de cambiar el cliente pensaría con la llave del dueño de la plataforma, y el consumo de un miembro se lo pagaría otro. En silencio, que es la peor forma.

Revienta con `RuntimeError` en vez de degradar: `LlmExhausted` haría que el turno siguiera su camino de «no pude pensar», y un olvido de cableado se leería como un fallo del proveedor.

## Por qué no lo atrapó nadie

**Todas las pruebas pasan `ctx=`**, así que `own_resources` es falso y la rama que arma los recursos no la ejercía ninguna. Es justo la rama que solo corre en producción.

Ahora hay dos que sí, con la base y los workers de mentira:

- el arranque multi-organización **no muere sin llave**, y deja el centinela puesto;
- ese centinela **revienta al usarse**, no degrada.

**Mutación verificada**: devolver el `OpenAiLlm` las pone rojas. Y la mutación enseña de paso el segundo fallo — la prueba se va a la red a hablar con un proveedor de verdad.

193 pruebas verdes.

## De paso

El comentario de `vocero_mode` en `config.py` seguía diciendo «una instancia atiende a UNA organización… atender a varios negocios hoy significa una instancia por negocio». Dejó de ser cierto en kevinrivm/nea-agent#12.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
