### PR TITLE
fix: la respuesta del cerebro no salía nunca

### DIFF
--- a/app/crm_brains.py
+++ b/app/crm_brains.py
@@ -27,8 +27,10 @@ import httpx
 from app.crm import (
     AgendaUnavailable,
     CrmClient,
+    CrmConflict,
     CrmError,
     _booking_conflict,
+    _conflict_code,
 )
 
 logger = logging.getLogger("nea.crm.brains")
@@ -66,6 +68,9 @@ class BrainsCrmClient(CrmClient):
         # De qué conversación es cada identidad. Lo llena el despacho: el CRM
         # ya sabe de quién es el mensaje, así que Nea no tiene que averiguarlo.
         self._conversaciones: dict[str, str] = {}
+        # Y qué despacho se está contestando en cada conversación: el CRM lo
+        # exige al responder, para no mandar dos veces lo mismo si reintenta.
+        self._despachos: dict[str, str] = {}
         # El perfil viaja DENTRO del contexto en esta superficie. Se guarda al
         # pedirlo para que `get_profile()` no gaste una llamada de más por
         # turno — y para que el perfil sea el de la conversación que se está
@@ -84,6 +89,24 @@ class BrainsCrmClient(CrmClient):
     def registrar(self, identity: str, conversation_id: str) -> None:
         """Asocia una identidad con su conversación, desde el despacho."""
         self._conversaciones[identity] = conversation_id
+
+    def registrar_despacho(self, conversation_id: str, dispatch_id: str) -> None:
+        """Asocia una conversación con el despacho que se está contestando.
+
+        `POST /api/brains/messages` EXIGE el `dispatchId` (contrato §2.1): es
+        lo que le deja al CRM ser idempotente, porque reintenta los despachos
+        y sin él respondería dos veces al mismo cliente final.
+
+        Se guarda aquí y no se pasa por parámetro porque el turno no sabe de
+        despachos —ni tiene por qué—: recibe una conversación y un texto. Es la
+        misma razón por la que `registrar` existe.
+        """
+        if dispatch_id:
+            self._despachos[conversation_id] = dispatch_id
+
+    def despacho_de(self, conversation_id: str) -> str:
+        """El despacho en curso de esa conversación, o cadena vacía."""
+        return self._despachos.get(conversation_id, "")
 
     async def precargar(self, conversation_id: str) -> dict[str, Any] | None:
         """Trae el contexto AHORA y lo deja listo para el turno.
@@ -120,6 +143,45 @@ class BrainsCrmClient(CrmClient):
 
     def _request(self, method: str, url: str, **kwargs: Any):  # type: ignore[override]
         return super()._request(method, RUTAS.get(url, url), **kwargs)
+
+    async def send_message(
+        self, conversation_id: str, text: str, dispatch_id: str = ""
+    ) -> dict[str, Any]:
+        """Responder por el cerebro. Dos cosas que el de `/api/bot` no hacía.
+
+        **Manda el `dispatchId`.** El de siempre solo manda conversación y
+        texto, así que el CRM rechazaba TODA respuesta con `422 invalid_body`.
+        Nea pensaba bien, pagaba el modelo, y el texto no salía nunca.
+
+        **Acepta cualquier 2xx.** Esta ruta responde `201` al crear, y el
+        contrato lo avisa con todas las letras: «no compares contra 200 (esa
+        comparación ya rompió toda la reserva de citas en producción una vez)».
+        El cliente hacía exactamente eso: aun con el body correcto habría
+        tratado el envío bueno como un fallo, y lo habría reintentado hasta
+        encolarlo — con el mensaje YA entregado al cliente final.
+        """
+        dispatch_id = dispatch_id or self.despacho_de(conversation_id)
+        resp = await self._request(
+            "POST",
+            "/api/bot/messages",
+            json={
+                "dispatchId": dispatch_id,
+                "conversationId": conversation_id,
+                "text": text,
+            },
+        )
+        if resp.status_code == 409:
+            raise CrmConflict(_conflict_code(resp))
+        # Ventana de 24 h cerrada. En `/api/bot` era un 409 y aquí es un 422
+        # (contrato §2.1). Se traduce al mismo conflicto para que el turno
+        # calle igual que siempre en vez de reintentar algo que no va a
+        # cambiar: la ventana no se abre reintentando.
+        if resp.status_code == 422 and _conflict_code(resp) == "fuera_de_ventana":
+            raise CrmConflict("window_closed")
+        if not resp.is_success:
+            raise CrmError(f"messages devolvió {resp.status_code}")
+        data: dict[str, Any] = resp.json()
+        return data
 
     async def get_context(self, wa_identity: str) -> dict[str, Any] | None:
         """El contexto, pedido por conversación y no por identidad.

--- a/app/db.py
+++ b/app/db.py
@@ -46,6 +46,35 @@ def _conv_from_row(row: asyncpg.Record) -> Conversation:
     )
 
 
+def _pending_send_desde_fila(row: Any) -> PendingSend:
+    """Una fila de `pending_send` → su dataclass.
+
+    Existe como función, y no suelto dentro de la consulta, por el fallo que
+    arregla: el mapeo iba campo a campo y se quedó SIN LEER las columnas de
+    organización que 004 había añadido. La fila las guardaba bien; al releerla
+    volvían vacías, así que el SenderWorker no sabía de quién era el envío y no
+    entregaba ninguno. La cola de "jamás se descarta" estaba muerta.
+
+    Las pruebas no lo vieron porque `MemoryStore` devuelve el objeto que
+    guardó: ahí no hay mapeo que equivocar. El único sitio donde este error
+    existe es el que las pruebas no tocan.
+    """
+    return PendingSend(
+        id=row["id"],
+        conversation_id=row["conversation_id"],
+        crm_conversation_id=row["crm_conversation_id"],
+        content=row["content"],
+        attempts=row["attempts"],
+        created_at=row["created_at"],
+        next_retry_at=row["next_retry_at"],
+        delivered_at=row["delivered_at"],
+        abandoned_at=row["abandoned_at"],
+        organization_id=row["organization_id"],
+        organization_slug=row["organization_slug"],
+        dispatch_id=row["dispatch_id"],
+    )
+
+
 class PgStore:
     """Store respaldado por Postgres (asyncpg)."""
 
@@ -303,19 +332,21 @@ class PgStore:
         content: str,
         organization_id: str = "",
         organization_slug: str = "",
+        dispatch_id: str = "",
     ) -> int:
         row = await self.pool.fetchrow(
             """
             INSERT INTO pending_send
               (conversation_id, crm_conversation_id, content,
-               organization_id, organization_slug)
-            VALUES ($1, $2, $3, $4, $5) RETURNING id
+               organization_id, organization_slug, dispatch_id)
+            VALUES ($1, $2, $3, $4, $5, $6) RETURNING id
             """,
             conversation_id,
             crm_conversation_id,
             content,
             organization_id,
             organization_slug,
+            dispatch_id,
         )
         assert row is not None
         return row["id"]
@@ -330,20 +361,7 @@ class PgStore:
             """,
             now,
         )
-        return [
-            PendingSend(
-                id=r["id"],
-                conversation_id=r["conversation_id"],
-                crm_conversation_id=r["crm_conversation_id"],
-                content=r["content"],
-                attempts=r["attempts"],
-                created_at=r["created_at"],
-                next_retry_at=r["next_retry_at"],
-                delivered_at=r["delivered_at"],
-                abandoned_at=r["abandoned_at"],
-            )
-            for r in rows
-        ]
+        return [_pending_send_desde_fila(r) for r in rows]
 
     async def mark_pending_send_delivered(self, pending_id: int) -> None:
         await self.pool.execute(

--- a/app/dispatch.py
+++ b/app/dispatch.py
@@ -156,6 +156,14 @@ async def _procesar(ctx: AppContext, payload: dict[str, Any]) -> None:
             registrar(identity, conversation_id)
         ctx_turno = ctx
 
+    # Y de qué despacho es. Sin esto el CRM rechaza la respuesta con 422: el
+    # `dispatchId` es lo que le deja no responder dos veces al mismo cliente
+    # cuando reintenta. Va aquí, para los dos modos, porque los dos contestan
+    # por la misma ruta.
+    registrar_despacho = getattr(ctx_turno.crm, "registrar_despacho", None)
+    if callable(registrar_despacho):
+        registrar_despacho(conversation_id, dispatch_id)
+
     # Directo al turno, sin coalescer: el CRM ya agrupó la ráfaga.
     await handle_flush(ctx_turno, identity, mensajes)
 

--- a/app/sender.py
+++ b/app/sender.py
@@ -67,6 +67,13 @@ class SenderWorker:
     async def _attempt(
         self, ctx: AppContext, item: PendingSend, now: datetime
     ) -> None:
+        # Qué despacho estaba contestando. El CRM lo exige para responder por
+        # el cerebro, y aquí el turno que lo sabía ya no existe: sale de la
+        # fila. Sin esto el reintento diferido se rechazaba con 422 hasta
+        # agotar las 24 h — la cola entera existía para nada.
+        registrar_despacho = getattr(ctx.crm, "registrar_despacho", None)
+        if callable(registrar_despacho):
+            registrar_despacho(item.crm_conversation_id, item.dispatch_id)
         try:
             await ctx.crm.send_message(item.crm_conversation_id, item.content)
         except CrmConflict as exc:

--- a/app/state.py
+++ b/app/state.py
@@ -97,6 +97,9 @@ class PendingSend:
     # con valor por defecto no puede preceder a uno sin él.
     organization_id: str = ""
     organization_slug: str = ""
+    # Y qué despacho estaba contestando: el CRM lo exige al responder por el
+    # cerebro, y cuando el worker despierta el turno ya no existe para dárselo.
+    dispatch_id: str = ""
 
 
 @dataclass
@@ -179,6 +182,7 @@ class Store(Protocol):
         content: str,
         organization_id: str = "",
         organization_slug: str = "",
+        dispatch_id: str = "",
     ) -> int: ...
     async def due_pending_sends(self, now: datetime) -> list[PendingSend]: ...
     async def mark_pending_send_delivered(self, pending_id: int) -> None: ...
@@ -328,6 +332,7 @@ class MemoryStore:
         content: str,
         organization_id: str = "",
         organization_slug: str = "",
+        dispatch_id: str = "",
     ) -> int:
         pid = next(self._ids)
         now = utcnow()
@@ -337,6 +342,7 @@ class MemoryStore:
             attempts=0, created_at=now, next_retry_at=now,
             organization_id=organization_id,
             organization_slug=organization_slug,
+            dispatch_id=dispatch_id,
         )
         return pid
 

--- a/app/turn.py
+++ b/app/turn.py
@@ -402,8 +402,13 @@ async def _send(ctx: AppContext, conv_id: int, crm_conv_id: str, text: str) -> b
     # —quizá horas después— tiene que hablarle al CRM con la credencial de
     # ESTA, y para entonces el turno ya no existe.
     org_id, org_slug = ctx.organizacion or ("", "")
+    # Y el despacho que se estaba contestando: el CRM lo exige para responder,
+    # y para cuando el worker despierte este turno ya no existe. El turno no lo
+    # sabe —recibe conversación y texto—, se lo pide al cliente, que sí.
+    despacho_de = getattr(ctx.crm, "despacho_de", None)
+    dispatch_id = despacho_de(crm_conv_id) if callable(despacho_de) else ""
     pending_id = await ctx.store.enqueue_pending_send(
-        conv_id, crm_conv_id, text, org_id, org_slug
+        conv_id, crm_conv_id, text, org_id, org_slug, dispatch_id
     )
     logger.error(
         "envío agotó reintentos del turno — encolado como pending_send %d",

--- a/migrations/005_pending_dispatch.sql
+++ b/migrations/005_pending_dispatch.sql
@@ -1,0 +1,16 @@
+-- El envío diferido necesita el despacho que estaba contestando.
+--
+-- `POST /api/brains/messages` EXIGE el `dispatchId` (contrato §2.1): es lo que
+-- le deja al CRM ser idempotente cuando reintenta un despacho, en vez de
+-- responderle dos veces al mismo cliente final.
+--
+-- El turno lo tenía a mano y la fila no lo guardaba, así que cuando el
+-- SenderWorker despertaba —quizá horas después, que es justo para lo que
+-- existe— su envío se rechazaba con 422 y volvía a la cola. Reintentando
+-- indefinidamente algo que no podía funcionar nunca.
+--
+-- Igual que en 004: cadena vacía, no NULL, para que las filas de siempre —las
+-- de una Nea de un solo negocio, que contesta por /api/bot y no manda
+-- despacho— sigan comportándose exactamente igual.
+ALTER TABLE pending_send
+  ADD COLUMN IF NOT EXISTS dispatch_id TEXT NOT NULL DEFAULT '';

--- a/tests/test_cloud_mode.py
+++ b/tests/test_cloud_mode.py
@@ -17,6 +17,7 @@ import pytest
 import respx
 
 from app.config import Settings
+from app.crm import CrmConflict, CrmError
 from app.crm_brains import (
     BrainsCrmClient,
     _aplanar_reserva,
@@ -193,14 +194,84 @@ class TestCliente:
     async def test_habla_con_brains_y_autentica_con_el_secreto(
         self, cliente: BrainsCrmClient
     ) -> None:
+        # 201, que es lo que responde de verdad. Estaba puesto 200, y por eso
+        # esta prueba pasaba en verde mientras producción no entregaba nada.
         ruta = respx.post(f"{CRM_URL}/api/brains/messages").mock(
-            return_value=httpx.Response(200, json={"ok": True})
+            return_value=httpx.Response(201, json={"message": {"id": "msg_1"}})
         )
         await cliente.send_message(CONV, "hola")
 
         pedido = ruta.calls.last.request
         assert pedido.headers["authorization"] == f"Bearer {SECRETO}"
         assert pedido.headers["x-vocero-organization"] == "mi-negocio"
+
+    @respx.mock
+    async def test_responder_manda_el_despacho_que_contesta(
+        self, cliente: BrainsCrmClient
+    ) -> None:
+        """Sin `dispatchId` el CRM rechaza la respuesta entera (422).
+
+        Es lo que le deja ser idempotente: reintenta los despachos, y sin esto
+        el mismo texto le llegaría dos veces al cliente final.
+        """
+        ruta = respx.post(f"{CRM_URL}/api/brains/messages").mock(
+            return_value=httpx.Response(201, json={"message": {"id": "msg_1"}})
+        )
+        cliente.registrar_despacho(CONV, "dsp_abc")
+        await cliente.send_message(CONV, "hola")
+
+        cuerpo = json.loads(ruta.calls.last.request.content)
+        assert cuerpo["dispatchId"] == "dsp_abc"
+        assert cuerpo["conversationId"] == CONV
+        assert cuerpo["text"] == "hola"
+
+    @respx.mock
+    async def test_un_201_no_es_un_fallo(self, cliente: BrainsCrmClient) -> None:
+        """El contrato lo avisa: «no compares contra 200».
+
+        Comparar rompería el envío BUENO: el mensaje ya salió al cliente y el
+        turno lo trataría como fallido, lo reintentaría, y acabaría encolado.
+        """
+        respx.post(f"{CRM_URL}/api/brains/messages").mock(
+            return_value=httpx.Response(201, json={"message": {"id": "msg_1"}})
+        )
+        assert await cliente.send_message(CONV, "hola") == {"message": {"id": "msg_1"}}
+
+    @respx.mock
+    async def test_la_ventana_cerrada_calla_en_vez_de_reintentar(
+        self, cliente: BrainsCrmClient
+    ) -> None:
+        """En `/api/bot` era un 409 y aquí es un 422 (contrato §2.1).
+
+        Tiene que llegar al turno como conflicto, no como error: reintentar no
+        abre la ventana, y cada intento cuenta contra la calidad del número.
+        """
+        respx.post(f"{CRM_URL}/api/brains/messages").mock(
+            return_value=httpx.Response(
+                422, json={"error": {"code": "fuera_de_ventana", "message": "cerrada"}}
+            )
+        )
+        with pytest.raises(CrmConflict) as exc:
+            await cliente.send_message(CONV, "hola")
+        assert exc.value.code == "window_closed"
+
+    @respx.mock
+    async def test_un_422_de_verdad_sigue_siendo_un_fallo(
+        self, cliente: BrainsCrmClient
+    ) -> None:
+        """Un body inválido NO se traga como "ventana cerrada".
+
+        Es el fallo que tumbó el primer despliegue: si se confundieran, el
+        síntoma sería un silencio educado en vez de un error, y nadie iría a
+        mirar por qué el agente no contesta.
+        """
+        respx.post(f"{CRM_URL}/api/brains/messages").mock(
+            return_value=httpx.Response(
+                422, json={"error": {"code": "invalid_body", "message": "falta algo"}}
+            )
+        )
+        with pytest.raises(CrmError):
+            await cliente.send_message(CONV, "hola")
 
     @respx.mock
     async def test_el_contexto_va_por_conversacion_no_por_telefono(

--- a/tests/test_multiorg.py
+++ b/tests/test_multiorg.py
@@ -16,11 +16,13 @@ import asyncio
 import base64
 import hashlib
 import hmac
+from dataclasses import fields
 
 import pytest
 
 from app import main
 from app.config import Settings
+from app.db import _conv_from_row
 from app.multiorg import (
     CrmSinOrganizacion,
     LlmSinOrganizacion,
@@ -29,7 +31,7 @@ from app.multiorg import (
     ctx_de_organizacion,
     organizacion_del_despacho,
 )
-from app.state import AppContext, MemoryStore
+from app.state import AppContext, Conversation, MemoryStore, utcnow
 
 SECRETO = "un-secreto-de-despliegue-largo-y-aburrido"
 ORG = "org_abc123"
@@ -372,3 +374,38 @@ async def test_el_modelo_del_arranque_revienta_al_usarse(arranque_multiorg):
     async with app.router.lifespan_context(app):
         with pytest.raises(RuntimeError, match="sin saber de qué organización"):
             await app.state.ctx.llm.complete([{"role": "user", "content": "hola"}])
+
+
+def test_el_mapeo_de_conversacion_no_se_deja_ninguna_columna():
+    """La hermana de la de `pending_send`, y esta duele más si falla.
+
+    Si el mapeo dejara de leer `organization_id`, toda conversación releída de
+    Postgres volvería «sin organización». El turno la trataría como la de una
+    instalación de un solo negocio y le hablaría al CRM con la credencial
+    equivocada: el historial de un negocio en el prompt de otro, que es
+    exactamente lo que 004 existe para impedir.
+
+    Contra `fields()` a propósito: el próximo campo que se añada no se puede
+    olvidar en el mapeo sin que esto se ponga rojo.
+    """
+    ahora = utcnow()
+    fila = {
+        "id": 1,
+        "wa_identity": "5215512345678",
+        "crm_conversation_id": "cv_abc",
+        "organization_id": "org_a",
+        "organization_slug": "negocio-a",
+        "phase": "descubrimiento",
+        "greeted": True,
+        "media_notice_sent": False,
+        "followup_due_at": None,
+        "followup_sent": False,
+        "last_inbound_at": ahora,
+        "stalled_at": None,
+    }
+    conv = _conv_from_row(fila)
+
+    for campo in fields(Conversation):
+        assert getattr(conv, campo.name) == fila[campo.name], (
+            f"el mapeo no lee {campo.name}"
+        )

--- a/tests/test_sender.py
+++ b/tests/test_sender.py
@@ -6,14 +6,39 @@ hipa): el turno encola en pending_send y el SenderWorker entrega con backoff.
 from __future__ import annotations
 
 import asyncio
+from dataclasses import fields
 from datetime import timedelta
 
 import httpx
 
 from app import turn
+from app.crm_brains import BrainsCrmClient
+from app.db import _pending_send_desde_fila
 from app.sender import SenderWorker
-from app.state import utcnow
-from tests.conftest import CRM_CONV_ID, CRM_URL, IDENTITY, make_ctx
+from app.state import AppContext, MemoryStore, PendingSend, utcnow
+from tests.conftest import (
+    CRM_CONV_ID,
+    CRM_URL,
+    IDENTITY,
+    FakeLLM,
+    make_ctx,
+    make_settings,
+)
+
+
+def _ctx_cerebro() -> AppContext:
+    """Una Nea contestando por `/api/brains`, con su organización puesta.
+
+    El `make_ctx` de siempre arma un cliente de `/api/bot`, que no manda
+    despacho ninguno: contra él estas pruebas pasarían sin probar nada.
+    """
+    return AppContext(
+        settings=make_settings(),
+        store=MemoryStore(),
+        crm=BrainsCrmClient(CRM_URL, "secreto-del-despliegue", "negocio-a"),
+        llm=FakeLLM(),
+        organizacion=("org_a", "negocio-a"),
+    )
 
 
 async def _sin_esperas(monkeypatch):
@@ -41,6 +66,57 @@ async def test_envio_agotado_se_encola_no_se_descarta(respx_mock, monkeypatch):
     assert len(pendientes) == 1
     assert pendientes[0].content == "respuesta importante"
     assert pendientes[0].crm_conversation_id == CRM_CONV_ID
+    await ctx.crm.aclose()
+
+
+async def test_la_cola_guarda_con_que_credencial_y_que_despacho(
+    respx_mock, monkeypatch
+):
+    """Lo que el worker necesitará cuando el turno ya no exista.
+
+    Despierta horas después, y para entonces no hay despacho del que sacar
+    nada: las dos cosas tienen que estar en la fila.
+
+    - **La organización**, para hablarle al CRM con la credencial de ESE
+      negocio y no con la de otro.
+    - **El despacho**, porque `/api/brains/messages` lo exige. Sin él, cada
+      reintento diferido se rechaza con 422 hasta agotar las 24 h: la cola
+      entera —la del incidente 2026-08-03— existiría para nada.
+    """
+    ctx = _ctx_cerebro()
+    ctx.crm.registrar_despacho(CRM_CONV_ID, "dsp_abc")
+    conv = await ctx.store.get_or_create_conversation(IDENTITY, "org_a", "negocio-a")
+    respx_mock.post(f"{CRM_URL}/api/brains/messages").mock(
+        return_value=httpx.Response(502, json={"code": "meta_unavailable"})
+    )
+    await _sin_esperas(monkeypatch)
+
+    await turn._send(ctx, conv.id, CRM_CONV_ID, "respuesta importante")
+
+    pendiente = (await ctx.store.due_pending_sends(utcnow()))[0]
+    assert pendiente.organization_id == "org_a"
+    assert pendiente.organization_slug == "negocio-a"
+    assert pendiente.dispatch_id == "dsp_abc"
+    await ctx.crm.aclose()
+
+
+async def test_el_reintento_diferido_manda_el_despacho_de_su_fila(respx_mock):
+    """Y el worker lo usa. De punta a punta, que es donde se rompió."""
+    ctx = _ctx_cerebro()
+    conv = await ctx.store.get_or_create_conversation(IDENTITY, "org_a", "negocio-a")
+    await ctx.store.enqueue_pending_send(
+        conv.id, CRM_CONV_ID, "respuesta importante", "org_a", "negocio-a", "dsp_abc"
+    )
+    ruta = respx_mock.post(f"{CRM_URL}/api/brains/messages").mock(
+        return_value=httpx.Response(201, json={"message": {"id": "msg_1"}})
+    )
+
+    await SenderWorker(ctx).tick()
+
+    import json as _json
+
+    assert _json.loads(ruta.calls.last.request.content)["dispatchId"] == "dsp_abc"
+    assert await ctx.store.due_pending_sends(utcnow()) == []  # entregado
     await ctx.crm.aclose()
 
 
@@ -138,3 +214,45 @@ async def test_sender_agota_24h_abandona_y_alerta(respx_mock):
     assert ctx.store.pending_sends[pid].abandoned_at is not None
     assert handoff.call_count == 1  # humano alertado vía handoff error
     await ctx.crm.aclose()
+
+
+# ── El mapeo de la fila ───────────────────────────────────────────────────
+
+
+def test_el_mapeo_de_pending_send_no_se_deja_ninguna_columna():
+    """Toda columna que se guarda se vuelve a leer.
+
+    El fallo que esto cierra: el mapeo iba campo a campo y se quedó sin leer
+    `organization_id`/`organization_slug`, que 004 había añadido. La fila las
+    guardaba bien y al releerla volvían vacías, así que el SenderWorker no
+    sabía de quién era el envío y lo abandonaba. La cola de «jamás se
+    descarta» estaba muerta y nadie se enteró.
+
+    Se comprueba contra `fields()` y no contra una lista escrita a mano para
+    que el próximo campo que alguien añada no pueda olvidarse: si no está en
+    el mapeo, esta prueba se pone roja sola.
+
+    `MemoryStore` no puede cubrir esto — devuelve el objeto que guardó, así que
+    no hay mapeo que equivocar. Este error solo existe contra Postgres.
+    """
+    ahora = utcnow()
+    fila = {
+        "id": 7,
+        "conversation_id": 3,
+        "crm_conversation_id": "cv_abc",
+        "content": "hola",
+        "attempts": 2,
+        "created_at": ahora,
+        "next_retry_at": ahora,
+        "delivered_at": None,
+        "abandoned_at": None,
+        "organization_id": "org_a",
+        "organization_slug": "negocio-a",
+        "dispatch_id": "dsp_1",
+    }
+    pendiente = _pending_send_desde_fila(fila)
+
+    for campo in fields(PendingSend):
+        assert getattr(pendiente, campo.name) == fila[campo.name], (
+            f"el mapeo no lee {campo.name}"
+        )


### PR DESCRIPTION
## El síntoma

Primera prueba en vivo. Todo funcionó menos lo último:

```
POST /vocero/dispatch                    200   el despacho llegó
GET  /api/brains/context                 200   credencial derivada OK
POST /api/brains/typing                  200   el cliente vio los tres puntos
POST /api/brains/llm/chat/completions    200   el CRM pensó con la llave del miembro
POST /api/brains/messages                422   ← y aquí, cuatro veces
ERROR envío agotó reintentos del turno — encolado como pending_send 1
ERROR sender: pending 1 sin organización conocida
```

Nea pensó. El miembro pagó ese consumo. El cliente final no recibió nada.

## Cuatro fallos, el mismo camino

**1 · No mandaba `dispatchId`.** El cliente de `/api/brains` hereda el `send_message` de `/api/bot`, que manda `{conversationId, text}`. Esta ruta exige además el despacho (contrato §2.1): es lo que le deja al CRM ser idempotente cuando reintenta, en vez de responderle dos veces al mismo cliente. `422 invalid_body`, el cuerpo entero rechazado.

**2 · Exigía 200, y esta ruta responde 201.** El contrato lo avisa literalmente:

> «**`201` al crear**, no 200. Acepta `2xx` en tu cliente; no compares contra 200 (esa comparación ya rompió toda la reserva de citas en producción una vez)».

El cliente hacía exactamente eso. Arreglar solo el punto 1 habría cambiado un fallo por otro peor: el envío **bueno** tratado como fallido, reintentado, y encolado — con el mensaje ya entregado al cliente final.

**3 · El mapeo de `pending_send` no leía las columnas de 004.** La fila guardaba su organización correctamente; al releerla volvía vacía. El SenderWorker no sabía de quién era el envío y lo abandonaba. La cola del incidente 2026-08-03 —«jamás se descarta»— estaba muerta en multi-organización, en silencio.

**4 · La fila no guardaba el despacho.** El worker despierta cuando el turno que lo sabía ya no existe. Sin él, cada reintento diferido se habría rechazado con 422 hasta agotar las 24 h: la cola habría existido para nada. Migración `005`.

**Y de paso**: la ventana de 24 h cerrada, que en `/api/bot` era 409 y aquí es 422, ahora llega al turno como conflicto. Reintentar no abre la ventana, y cada intento cuenta contra la calidad del número del miembro.

## Por qué 193 pruebas verdes no vieron nada

Dos motivos, y los dos son el mismo: **la prueba se creía su propia ficción**.

- La del envío devolvía un `200` inventado. Enseñaba un contrato que no existe, así que blindaba justo el fallo.
- `MemoryStore` devuelve el objeto que guardó. Donde las pruebas miran no hay mapeo que equivocar; el error solo existe contra Postgres.

Los dos mapeos se comprueban ahora contra `fields()` del dataclass, no contra una lista escrita a mano: **la próxima columna que alguien añada no se puede olvidar sin poner rojo**. El de conversaciones también, que no estaba roto pero tampoco tenía quien lo defendiera — y ahí el fallo sería peor: una conversación releída «sin organización» pondría el historial de un negocio en el prompt de otro.

## Cómo se probó

201 pruebas. **Seis mutaciones verificadas** — apagar cada arreglo pone rojo algo:

| Mutación | Se pone roja |
|---|---|
| quitar `dispatchId` del cuerpo | `test_responder_manda_el_despacho_que_contesta` |
| volver a exigir 200 | `test_un_201_no_es_un_fallo` |
| el mapeo de `pending_send` pierde la organización | `test_el_mapeo_de_pending_send_...` |
| el mapeo de conversación pierde la organización | `test_el_mapeo_de_conversacion_...` |
| la fila no guarda el despacho | `test_la_cola_guarda_con_que_credencial_...` |
| el sender no lo registra al reintentar | `test_el_reintento_diferido_manda_el_despacho_...` |

🤖 Generated with [Claude Code](https://claude.com/claude-code)
