### PR TITLE
fix: escalar sin token del miembro no es un error del proveedor

### DIFF
--- a/app/dispatch.py
+++ b/app/dispatch.py
@@ -207,7 +207,7 @@ async def _contexto_multiorg(
         logger.warning(
             "%s: el CRM no dio contexto de %s — sin turno", slug, conversation_id
         )
-        await _a_humano(cliente, conversation_id)
+        await _a_humano(cliente, conversation_id, "error")
         return None
 
     config_ia = cliente.credenciales_llm()
@@ -223,7 +223,7 @@ async def _contexto_multiorg(
             slug,
             conversation_id,
         )
-        await _a_humano(cliente, conversation_id)
+        await _a_humano(cliente, conversation_id, "sin_credencial")
         return None
 
     return replace(
@@ -235,14 +235,20 @@ async def _contexto_multiorg(
     )
 
 
-async def _a_humano(cliente: Any, conversation_id: str) -> None:
+async def _a_humano(cliente: Any, conversation_id: str, motivo: str) -> None:
     """Marca la conversación para un humano, sin que eso pueda tumbar nada.
 
     Si hasta el handoff falla ya solo queda el log: el mensaje del cliente está
     guardado en la bandeja del CRM desde antes de que Nea lo viera, así que no
     se pierde nada aunque esta llamada no llegue.
+
+    El `motivo` es obligatorio y no tiene valor por defecto a propósito. Lo
+    tuvo —"error"— y por eso el miembro sin token leía «Error del proveedor de
+    IA» en su bandeja: un mensaje que manda a revisar OpenRouter cuando al
+    proveedor no se le había llamado siquiera. Quien escala sabe por qué; el
+    default lo único que hacía era dejarle no decirlo.
     """
     try:
-        await cliente.post_handoff(conversation_id, "error")
+        await cliente.post_handoff(conversation_id, motivo)
     except Exception:
         logger.exception("no pude marcar %s para humano", conversation_id)

--- a/tests/test_motivo_handoff.py
+++ b/tests/test_motivo_handoff.py
@@ -1,0 +1,93 @@
+"""El motivo con el que Nea devuelve una conversación a un humano.
+
+Importa más de lo que parece: es el texto que el miembro lee en su bandeja
+cuando su agente se calló. Mientras todo escalaba como "error", quien no había
+pegado su token de OpenRouter leía «Error del proveedor de IA» — y se iba a
+revisar el estado de un proveedor al que nunca se llamó.
+"""
+
+from typing import Any
+
+import pytest
+
+from app.dispatch import _a_humano, _contexto_multiorg
+
+
+class _CrmQueAnota:
+    """Anota el motivo del handoff y nada más."""
+
+    def __init__(self, config_ia: Any = None, contexto: Any = None) -> None:
+        self.motivos: list[str] = []
+        self._config_ia = config_ia
+        self._contexto = contexto
+
+    def registrar(self, identity: str, conversation_id: str) -> None:
+        return None
+
+    async def precargar(self, conversation_id: str) -> Any:
+        return self._contexto
+
+    def credenciales_llm(self) -> Any:
+        return self._config_ia
+
+    async def post_handoff(self, conversation_id: str, reason: str) -> None:
+        self.motivos.append(reason)
+
+
+class _RegistroDePrueba:
+    def __init__(self, crm: _CrmQueAnota) -> None:
+        self._crm = crm
+
+    def cliente(self, org_id: str, slug: str) -> _CrmQueAnota:
+        return self._crm
+
+
+class _CtxDePrueba:
+    """Lo mínimo que `_contexto_multiorg` mira antes de rendirse."""
+
+    def __init__(self, registro: Any) -> None:
+        self.registro = registro
+
+
+PAYLOAD = {"organization": {"id": "org_1", "slug": "allok"}}
+
+
+@pytest.mark.asyncio
+async def test_sin_token_del_miembro_el_motivo_no_es_error() -> None:
+    crm = _CrmQueAnota(config_ia=None, contexto={"algo": True})
+    ctx = _CtxDePrueba(_RegistroDePrueba(crm))
+
+    resultado = await _contexto_multiorg(ctx, PAYLOAD, "521999", "cv_1")
+
+    assert resultado is None, "sin con qué pensar, no hay turno"
+    # El fondo del asunto: al proveedor NO se le llamó, así que decir que
+    # falló es mandar al miembro a buscar una avería que no existe.
+    assert crm.motivos == ["sin_credencial"]
+
+
+@pytest.mark.asyncio
+async def test_si_el_crm_no_da_contexto_eso_si_es_un_error() -> None:
+    crm = _CrmQueAnota(config_ia={"path": "/x", "model": "m"}, contexto=None)
+    ctx = _CtxDePrueba(_RegistroDePrueba(crm))
+
+    resultado = await _contexto_multiorg(ctx, PAYLOAD, "521999", "cv_1")
+
+    assert resultado is None
+    assert crm.motivos == ["error"]
+
+
+@pytest.mark.asyncio
+async def test_el_motivo_viaja_tal_cual_al_crm() -> None:
+    crm = _CrmQueAnota()
+    await _a_humano(crm, "cv_1", "sin_credencial")
+    assert crm.motivos == ["sin_credencial"]
+
+
+@pytest.mark.asyncio
+async def test_un_handoff_que_falla_no_tumba_el_turno() -> None:
+    class _CrmRoto:
+        async def post_handoff(self, conversation_id: str, reason: str) -> None:
+            raise RuntimeError("el CRM no contesta")
+
+    # No debe propagar: el mensaje del cliente ya está guardado en la bandeja.
+    await _a_humano(_CrmRoto(), "cv_1", "sin_credencial")


### PR DESCRIPTION
## Qué pasaba

Cuando el CRM no le ofrece a Nea con qué pensar, Nea hace lo correcto: se calla y devuelve la conversación a un humano. Pero escalaba con motivo `"error"`, y en la bandeja del miembro eso se lee:

> **Error del proveedor de IA**

Al proveedor no se le había llamado. El miembro no tenía token de OpenRouter. Ese texto lo manda a revisar el estado de OpenRouter buscando una avería que no existe.

Pasó de verdad hoy con una organización real, y costó una sesión entera de diagnóstico.

## Qué cambia

- La rama «el CRM no ofrece IA» manda **`sin_credencial`**.
- La rama «el CRM no dio contexto» sigue mandando `error`, que ahí sí lo es.
- `_a_humano` **pierde el valor por defecto** del motivo. Lo tenía (`"error"`), y era justo lo que permitía escalar sin decir por qué: quien escala siempre sabe la razón; el default solo le dejaba callársela.

Necesita el PR hermano en `vocerocrm-cloud`, que añade `sin_credencial` al catálogo y su etiqueta. Sin él, el CRM lo degrada silenciosamente a `modelo` — el catálogo tiene fallback, no error.

## Comprobado

- **205 pruebas** (antes 201), 4 nuevas en `tests/test_motivo_handoff.py`.
- **Mutación**: devuelto el motivo a `"error"`, cae exactamente la prueba que lo cubre. Restaurado, verde.

Las nuevas cubren también que un handoff que falla no tumbe el turno: el mensaje del cliente ya está en la bandeja antes de que Nea lo vea.
