### PR TITLE
perf: razonamiento al minimo y ruteo por rendimiento

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -87,6 +87,40 @@ class Settings(BaseSettings):
             "LLM_TRANSCRIBE_MODEL", "OPENAI_TRANSCRIBE_MODEL"
         ),
     )
+
+    # Esfuerzo de razonamiento del modelo. "minimal" lo baja al mínimo.
+    #
+    # El razonamiento se cobra en segundos que el cliente pasa mirando
+    # "escribiendo…". Medido en huaraches-nea el 7-sep contra GLM 5.3 Flash:
+    # con razonamiento, 150 tokens PENSANDO por cada 146 caracteres de
+    # respuesta y 4.4 s; con "minimal", 2.0 s y cero. El mismo modelo y la
+    # misma respuesta.
+    #
+    # Vacía = no se manda el parámetro y decide el proveedor. Un modelo que no
+    # entienda `reasoning` lo ignora: va por `extra_body`, fuera del contrato
+    # de OpenAI. Y si alguno se quejara, la llamada se reintenta sin él (ver
+    # `llm.py`) — bajar el tiempo no puede costar una respuesta.
+    llm_reasoning_effort: str = Field(
+        default="minimal", validation_alias=AliasChoices("LLM_REASONING_EFFORT")
+    )
+
+    # A qué proveedor de OpenRouter ir. "throughput" = al más rápido.
+    #
+    # La misma llamada tardaba 5.4 s o 19.6 s según a quién la ruteara: la
+    # varianza entre proveedores era MAYOR que cualquier optimización del
+    # prompt. Vacía = decide OpenRouter, que ordena por precio.
+    llm_provider_sort: str = Field(
+        default="throughput", validation_alias=AliasChoices("LLM_PROVIDER_SORT")
+    )
+
+    # NO hay tope de tokens de salida, y es una decisión, no un olvido.
+    #
+    # En huaraches se puso uno el 8-sep con un banco que prometía partir a la
+    # mitad el peor caso. En producción hizo lo contrario: el modelo gastaba
+    # los tokens razonando, chocaba con la pared y había que repetir la
+    # llamada entera. Un turno de 53 s. El tope convertía UNA llamada lenta en
+    # DOS. Se quitó el mismo día.
+
     history_window: int = 10
 
     # Guardarraíles y tiempos

--- a/app/llm.py
+++ b/app/llm.py
@@ -83,6 +83,8 @@ class OpenAiLlm:
         transcribe_model: str = "whisper-1",
         base_url: str | None = None,
         default_headers: dict[str, str] | None = None,
+        reasoning_effort: str = "",
+        provider_sort: str = "",
     ) -> None:
         # base_url ≠ None → proveedor OpenAI-compatible (p. ej. OpenRouter,
         # para el bench de modelos del 002). Ojo: la transcripción de audio
@@ -96,6 +98,11 @@ class OpenAiLlm:
         )
         self._model = model
         self._transcribe_model = transcribe_model
+        # Los dos ajustes de velocidad. Se deciden una vez, aqui, y viajan en
+        # cada llamada; `_extras_ok` los apaga solos si el proveedor se queja.
+        self._reasoning_effort = reasoning_effort.strip()
+        self._provider_sort = provider_sort.strip()
+        self._extras_ok = True
         # Con proveedor propio (OpenRouter y compañía) no hay endpoint de
         # transcripción: el audio se manda DENTRO del chat, a un modelo que
         # sepa oír. Se decide aquí y no en cada llamada para que el camino sea
@@ -203,6 +210,48 @@ class OpenAiLlm:
                 await asyncio.sleep(1.0)
         raise LlmExhausted(str(last_error))
 
+    def _extras(self) -> dict[str, Any]:
+        """Los ajustes que no son del contrato de OpenAI.
+
+        Van por `extra_body` a proposito: OpenRouter los entiende y un
+        proveedor que no, los ignora en vez de fallar.
+
+        OJO con `reasoning: {"exclude": true}`: parece lo mismo que "minimal"
+        y no lo es. Oculta el razonamiento de la respuesta pero el modelo lo
+        SIGUE generando - medido en huaraches el 8-sep: 650 tokens y 19.7 s de
+        mediana contra 67 y 7.7 s con "minimal". Que nadie lo "mejore".
+        """
+        if not self._extras_ok:
+            return {}
+        extra: dict[str, Any] = {}
+        if self._reasoning_effort:
+            extra["reasoning"] = {"effort": self._reasoning_effort}
+        if self._provider_sort:
+            extra["provider"] = {"sort": self._provider_sort}
+        return extra
+
+    def _quiza_por_los_extras(self, exc: Exception) -> None:
+        """Si el proveedor se quejo de `reasoning` o `provider`, se apagan.
+
+        Aqui pasan modelos de muchos miembros, no uno solo elegido por
+        nosotros. Bajar el tiempo de respuesta es una optimizacion, y una
+        optimizacion no puede costar la respuesta: al primer reproche este
+        cliente deja de mandarlos y el reintento sale limpio.
+
+        Es pegajoso a proposito -el soporte del modelo no cambia a media vida
+        del proceso- y por organizacion, porque cada una tiene el suyo.
+        """
+        if not self._extras_ok:
+            return
+        texto = str(exc).lower()
+        if "reasoning" in texto or "provider" in texto:
+            self._extras_ok = False
+            logger.warning(
+                "llm: %s no acepta los ajustes de velocidad - se apagan para "
+                "este modelo y se reintenta sin ellos",
+                self._model,
+            )
+
     async def complete(
         self,
         messages: list[dict[str, Any]],
@@ -215,6 +264,9 @@ class OpenAiLlm:
                 if tools:
                     kwargs["tools"] = tools
                     kwargs["tool_choice"] = "auto"
+                extra = self._extras()
+                if extra:
+                    kwargs["extra_body"] = extra
                 resp = await self._client.chat.completions.create(
                     model=self._model, messages=messages, **kwargs
                 )
@@ -232,6 +284,7 @@ class OpenAiLlm:
                 logger.warning("llm: respuesta vacía, intento %d", attempt + 1)
             except Exception as exc:  # red, API, parseo — todo reintenta
                 last_error = exc
+                self._quiza_por_los_extras(exc)
                 logger.warning("llm: fallo en intento %d: %s", attempt + 1, exc)
             if attempt < self.RETRIES:
                 await asyncio.sleep(2**attempt)  # 1 s, 2 s

--- a/app/main.py
+++ b/app/main.py
@@ -105,6 +105,8 @@ def create_app(ctx: AppContext | None = None) -> FastAPI:
                         settings.llm_model,
                         transcribe_model=settings.llm_transcribe_model,
                         base_url=settings.llm_base_url or None,
+                        reasoning_effort=settings.llm_reasoning_effort,
+                        provider_sort=settings.llm_provider_sort,
                     )
                 ),
                 # En multi-organización el perfil es de cada negocio y lo

--- a/app/multiorg.py
+++ b/app/multiorg.py
@@ -176,6 +176,11 @@ class RegistroDeOrganizaciones:
                 transcribe_model=transcribe,
                 base_url=base_url,
                 default_headers={"X-Vocero-Organization": slug},
+                # Los ajustes de velocidad son de esta Nea, no del miembro:
+                # el CRM reenvia el cuerpo TAL CUAL, asi que `extra_body`
+                # llega al proveedor igual que en mono-organizacion.
+                reasoning_effort=por_defecto.llm_reasoning_effort,
+                provider_sort=por_defecto.llm_provider_sort,
             )
             self._llms[clave] = cliente
         return cliente

--- a/tests/test_velocidad.py
+++ b/tests/test_velocidad.py
@@ -1,0 +1,145 @@
+"""Los ajustes de velocidad: razonamiento al minimo y ruteo por rendimiento.
+
+El razonamiento del modelo se cobra en segundos que el cliente pasa mirando
+"escribiendo…". Medido en huaraches-nea contra GLM 5.3 Flash: con razonamiento,
+4.4 s y 150 tokens PENSANDO por cada 146 caracteres de respuesta; con
+"minimal", 2.0 s y cero. Y la misma llamada tardaba 5.4 s o 19.6 s segun a que
+proveedor la ruteara OpenRouter — mas varianza que cualquier arreglo del
+prompt.
+
+Lo que estos tests protegen no es la velocidad (eso se mide en vivo), sino que
+BAJAR EL TIEMPO NUNCA CUESTE UNA RESPUESTA: aqui pasan los modelos de muchos
+miembros, no uno solo elegido por nosotros.
+"""
+from __future__ import annotations
+
+import json
+
+import httpx
+import pytest
+import respx
+
+from app.config import Settings
+from app.llm import LlmExhausted, OpenAiLlm
+
+pytestmark = pytest.mark.anyio
+
+
+def _ok(texto: str = "hola") -> httpx.Response:
+    return httpx.Response(
+        200, json={"choices": [{"message": {"role": "assistant", "content": texto}}]}
+    )
+
+
+class TestPorDefecto:
+    def test_los_dos_ajustes_vienen_encendidos(self) -> None:
+        s = Settings()
+        assert s.llm_reasoning_effort == "minimal"
+        assert s.llm_provider_sort == "throughput"
+
+    def test_no_hay_tope_de_salida(self) -> None:
+        # Un tope convirtio UNA llamada lenta en DOS: el modelo gastaba los
+        # tokens razonando, chocaba con la pared y habia que repetirla entera.
+        assert not hasattr(Settings(), "llm_max_tokens")
+
+
+class TestLoQueViajaEnLaLlamada:
+    @respx.mock
+    async def test_van_en_extra_body_no_en_el_cuerpo_de_openai(self) -> None:
+        ruta = respx.post("https://prov.test/chat/completions").mock(
+            return_value=_ok()
+        )
+        llm = OpenAiLlm(
+            "k", "m", base_url="https://prov.test",
+            reasoning_effort="minimal", provider_sort="throughput",
+        )
+        await llm.complete([{"role": "user", "content": "hola"}])
+
+        enviado = json.loads(ruta.calls.last.request.content)
+        assert enviado["reasoning"] == {"effort": "minimal"}
+        assert enviado["provider"] == {"sort": "throughput"}
+        # El tope sigue sin existir: que no vuelva por la puerta de atras.
+        assert "max_tokens" not in enviado
+
+    @respx.mock
+    async def test_vacios_no_se_mandan(self) -> None:
+        # Vacio = decide el proveedor. Mandar la clave con "" no es lo mismo.
+        ruta = respx.post("https://prov.test/chat/completions").mock(
+            return_value=_ok()
+        )
+        llm = OpenAiLlm("k", "m", base_url="https://prov.test")
+        await llm.complete([{"role": "user", "content": "hola"}])
+
+        enviado = json.loads(ruta.calls.last.request.content)
+        assert "reasoning" not in enviado
+        assert "provider" not in enviado
+
+
+class TestElSeguro:
+    """Un modelo que no los acepte tiene que contestar igual."""
+
+    @respx.mock
+    async def test_si_el_proveedor_se_queja_se_apagan_y_contesta(self) -> None:
+        llamadas: list[dict] = []
+
+        def responder(request: httpx.Request) -> httpx.Response:
+            cuerpo = json.loads(request.content)
+            llamadas.append(cuerpo)
+            if "reasoning" in cuerpo:
+                return httpx.Response(
+                    400, json={"error": {"message": "Reasoning is not supported"}}
+                )
+            return _ok("contesto igual")
+
+        respx.post("https://prov.test/chat/completions").mock(side_effect=responder)
+        llm = OpenAiLlm(
+            "k", "modelo-sin-razonamiento", base_url="https://prov.test",
+            reasoning_effort="minimal", provider_sort="throughput",
+        )
+        reply = await llm.complete([{"role": "user", "content": "hola"}])
+
+        # El cliente NO se rinde: reintenta sin los ajustes y responde.
+        assert reply.content == "contesto igual"
+        assert "reasoning" in llamadas[0]
+        assert "reasoning" not in llamadas[-1]
+
+    @respx.mock
+    async def test_apagados_se_quedan_apagados(self) -> None:
+        # El soporte del modelo no cambia a media vida del proceso: preguntarlo
+        # en cada turno seria pagar un fallo por turno.
+        def responder(request: httpx.Request) -> httpx.Response:
+            cuerpo = json.loads(request.content)
+            if "reasoning" in cuerpo:
+                return httpx.Response(
+                    400, json={"error": {"message": "Reasoning is not supported"}}
+                )
+            return _ok()
+
+        ruta = respx.post("https://prov.test/chat/completions").mock(
+            side_effect=responder
+        )
+        llm = OpenAiLlm(
+            "k", "m", base_url="https://prov.test", reasoning_effort="minimal"
+        )
+        await llm.complete([{"role": "user", "content": "una"}])
+        antes = len(ruta.calls)
+        await llm.complete([{"role": "user", "content": "otra"}])
+
+        # El segundo turno sale limpio al primer intento.
+        assert len(ruta.calls) == antes + 1
+        assert "reasoning" not in json.loads(ruta.calls.last.request.content)
+
+    @respx.mock
+    async def test_un_fallo_que_no_es_de_los_ajustes_no_los_apaga(self) -> None:
+        # Una caida de red no dice nada sobre si el modelo razona.
+        ruta = respx.post("https://prov.test/chat/completions").mock(
+            return_value=httpx.Response(500, json={"error": {"message": "boom"}})
+        )
+        llm = OpenAiLlm(
+            "k", "m", base_url="https://prov.test", reasoning_effort="minimal"
+        )
+        with pytest.raises(LlmExhausted):
+            await llm.complete([{"role": "user", "content": "hola"}])
+
+        assert llm._extras_ok is True
+        assert all("reasoning" in json.loads(c.request.content) for c in ruta.calls)


### PR DESCRIPTION
Nea tardaba demasiado en contestar. Traigo los dos ajustes que **si** funcionaron en `huaraches-nea`, y dejo fuera el que alli salio mal.

## Lo que se trae

| | Antes | Con el ajuste |
|---|---|---|
| Razonamiento (GLM 5.3 Flash, prompt real) | 4.4 s, 150 tokens pensando | **2.0 s, cero** |
| Ruteo de OpenRouter, misma llamada | 5.4 s **o** 19.6 s segun proveedor | ordenado por rendimiento |

- `LLM_REASONING_EFFORT` — por defecto `minimal`
- `LLM_PROVIDER_SORT` — por defecto `throughput`

Viajan en `extra_body`, fuera del contrato de OpenAI: un proveedor que no los entienda los ignora en vez de fallar. En modo nube el CRM reenvia el cuerpo tal cual, asi que llegan igual.

## Lo que NO se trae

**El tope de tokens de salida.** En huaraches prometia partir a la mitad el peor caso y en produccion hizo lo contrario: el modelo gastaba los tokens razonando, chocaba con la pared y habia que repetir la llamada entera. Un turno de 53 s. Se quito el mismo dia. Queda anotado en `config.py` para que nadie lo reintroduzca.

## El seguro que aqui si hace falta

En huaraches el modelo es uno y lo elegimos nosotros. Aqui pasan los modelos de **muchos miembros**. Si el proveedor se queja de `reasoning` o `provider`, el cliente de esa organizacion los apaga y reintenta sin ellos — y se quedan apagados, porque el soporte de un modelo no cambia a media vida del proceso.

Bajar el tiempo de respuesta es una optimizacion, y una optimizacion no puede costar la respuesta.

## Verificacion

212 pruebas en verde, siete nuevas. Falta la prueba en vivo en `dev.vocerocrm.com` con la Nea de dev — va despues del merge, porque esa app despliega esta rama.

🤖 Generated with [Claude Code](https://claude.com/claude-code)